### PR TITLE
Prevent SyntaxError when rewriting dict((a, b)for a, b in y)

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -359,7 +359,12 @@ def _process_dict_comp(tokens, start, arg):
     end_index = dict_victims.ends.pop()
 
     tokens[end_index] = Token('OP', '}')
-    for index in reversed(elt_victims.ends + dict_victims.ends):
+    for index in reversed(dict_victims.ends):
+        del tokens[index]
+    # See #6, Fix SyntaxError from rewriting dict((a, b)for a, b in y)
+    if tokens[elt_victims.ends[-1] + 1].src == 'for':
+        tokens.insert(elt_victims.ends[-1] + 1, Token(UNIMPORTANT_WS, ' '))
+    for index in reversed(elt_victims.ends):
         del tokens[index]
     tokens[elt_victims.first_comma_index] = Token('OP', ':')
     for index in reversed(dict_victims.starts + elt_victims.starts):

--- a/tests/pyupgrade_test.py
+++ b/tests/pyupgrade_test.py
@@ -165,6 +165,8 @@ def test_sets(s, expected):
             'dict((k, dict((k2, v2) for k2, v2 in y2)) for k, y2 in y)',
             '{k: {k2: v2 for k2, v2 in y2} for k, y2 in y}',
         ),
+        # This doesn't get fixed by autopep8 and can cause a syntax error
+        ('dict((a, b)for a, b in y)', '{a: b for a, b in y}'),
     ),
 )
 def test_dictcomps(s, expected):


### PR DESCRIPTION
Resolves #6