### PR TITLE
Don't rewrite format literals with formats in formats

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -74,8 +74,8 @@ def _rewrite_string_literal(literal):
     last_int = -1
     # The last segment will always be the end of the string and not a format
     # We slice it off here to avoid a "None" format key
-    for _, fmtkey, _, _ in parsed_fmt[:-1]:
-        if inty(fmtkey) and int(fmtkey) == last_int + 1:
+    for _, fmtkey, spec, _ in parsed_fmt[:-1]:
+        if inty(fmtkey) and int(fmtkey) == last_int + 1 and '{' not in spec:
             last_int += 1
         else:
             return literal

--- a/tests/pyupgrade_test.py
+++ b/tests/pyupgrade_test.py
@@ -231,6 +231,8 @@ def test_dictcomps(s, expected):
             "    'bar{}'.format(1, 2)\n"
             ')',
         ),
+        # Formats can be embedded in formats, leave these alone?
+        ("'{0:<{1}}'.format(1, 4)", "'{0:<{1}}'.format(1, 4)"),
     ),
 )
 def test_format_literals(s, expected):


### PR DESCRIPTION
Was curious what changes it would make on some large repository, found a syntax error afterwards!