### PR TITLE
Improve performance rewriting numeric literals

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -494,15 +494,10 @@ def _fix_escape_sequences(contents_text):
     return tokens_to_src(tokens)
 
 
-def _fix_long_literals(contents_text):
-    tokens = src_to_tokens(contents_text)
-    for i, token in enumerate(tokens):
-        if token.name == 'NUMBER':
-            tokens[i] = token._replace(src=token.src.rstrip('lL'))
-    return tokens_to_src(tokens)
+def _fix_tokens(contents_text):
+    def _fix_long(src):
+        return src.rstrip('lL')
 
-
-def _fix_octal_literals(contents_text):
     def _fix_octal(s):
         if not s.startswith('0') or not s.isdigit() or s == len(s) * '0':
             return s
@@ -514,7 +509,7 @@ def _fix_octal_literals(contents_text):
     tokens = src_to_tokens(contents_text)
     for i, token in enumerate(tokens):
         if token.name == 'NUMBER':
-            tokens[i] = token._replace(src=_fix_octal(token.src))
+            tokens[i] = token._replace(src=_fix_long(_fix_octal(token.src)))
     return tokens_to_src(tokens)
 
 
@@ -1312,8 +1307,7 @@ def fix_file(filename, args):
     contents_text = _fix_format_literals(contents_text)
     contents_text = _fix_unicode_literals(contents_text, args.py3_plus)
     contents_text = _fix_escape_sequences(contents_text)
-    contents_text = _fix_long_literals(contents_text)
-    contents_text = _fix_octal_literals(contents_text)
+    contents_text = _fix_tokens(contents_text)
     if not args.keep_percent_format:
         contents_text = _fix_percent_format(contents_text)
     if args.py3_plus:

--- a/tests/pyupgrade_test.py
+++ b/tests/pyupgrade_test.py
@@ -11,13 +11,12 @@ from pyupgrade import _fix_dictcomps
 from pyupgrade import _fix_escape_sequences
 from pyupgrade import _fix_format_literals
 from pyupgrade import _fix_fstrings
-from pyupgrade import _fix_long_literals
 from pyupgrade import _fix_new_style_classes
-from pyupgrade import _fix_octal_literals
 from pyupgrade import _fix_percent_format
 from pyupgrade import _fix_sets
 from pyupgrade import _fix_six
 from pyupgrade import _fix_super
+from pyupgrade import _fix_tokens
 from pyupgrade import _fix_unicode_literals
 from pyupgrade import _imports_unicode_literals
 from pyupgrade import _is_bytestring
@@ -382,7 +381,7 @@ def test_fix_escape_sequences(s, expected):
     ),
 )
 def test_long_literals(s, expected):
-    assert _fix_long_literals(s) == expected
+    assert _fix_tokens(s) == expected
 
 
 @pytest.mark.parametrize(
@@ -395,7 +394,7 @@ def test_long_literals(s, expected):
     ),
 )
 def test_noop_octal_literals(s):
-    assert _fix_octal_literals(s) == s
+    assert _fix_tokens(s) == s
 
 
 @pytest.mark.xfail(sys.version_info >= (3,), reason='python2 "feature"')
@@ -407,7 +406,7 @@ def test_noop_octal_literals(s):
     ),
 )
 def test_fix_octal_literal(s, expected):
-    assert _fix_octal_literals(s) == expected
+    assert _fix_tokens(s) == expected
 
 
 @pytest.mark.parametrize('s', ("b''", 'b""', 'B""', "B''", "rb''", "rb''"))


### PR DESCRIPTION
From profiling, this improves runtime by ~16%

There are additional gains that could be made here by also combining the `unicode_literals` and `escape_sequences` fixers as well into this loop