### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,6 +7,7 @@ setup(
     version='1.11.0',
     author='Anthony Sottile',
     author_email='asottile@umich.edu',
+    license='MIT',
     classifiers=[
         'License :: OSI Approved :: MIT License',
         'Programming Language :: Python :: 2',


### PR DESCRIPTION
The wheel package format supports including the license file. This is
done using the [metadata] section in the setup.cfg file. For additional
information on this feature, see:

https://wheel.readthedocs.io/en/stable/user_guide.html#including-license-files-in-the-generated-wheel-file

Helps project comply with its own license:

> The above copyright notice and this permission notice shall be
> included in all copies or substantial portions of the Software.