### PR TITLE
Actually include LICENSE in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.md LICENSE

--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,4 @@
 universal = True
 
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
Turns out #90 only adds LICENSE to the wheel.
This ensures that LICENSE and README.md are also
in the sdist.