### PR TITLE
Add py38 to Tox

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 project = pyupgrade
 # These should match the travis env list
-envlist = py27,py36,py37,pypy
+envlist = py27,py36,py37,py38,pypy
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
`# These should match the travis env list`

So remove `py37`?