### PR TITLE
Utilize rfind_string_parts to improve .format() rewrite

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -23,7 +23,7 @@ classifiers =
 [options]
 py_modules = pyupgrade
 install_requires =
-    tokenize-rt>=3.1.0
+    tokenize-rt>=3.2.0
     typing; python_version=="2.7"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 


### PR DESCRIPTION
this'll also improve performance of all runs of `pyupgrade` since it avoids an extra tokenize-untokenize \o/