### PR TITLE
Rewrite `io.open` to `open`

### DIFF
--- a/README.md
+++ b/README.md
@@ -284,6 +284,20 @@ six.assertRaisesRegex(self, e, r, fn)   # self.assertRaisesRegex(e, r, fn)
 six.assertRegex(self, s, r)             # self.assertRegex(s, r)
 ```
 
+### `open` alias
+
+Availability:
+- `--py3-plus` is passed on the commandline.
+
+```python
+# input
+with io.open('f.txt') as f:
+    pass
+# output
+with open('f.txt') as f:
+    pass
+```
+
 ### `OSError` aliases
 
 Availability:

--- a/tests/io_open_test.py
+++ b/tests/io_open_test.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+from __future__ import absolute_import
+from __future__ import unicode_literals
+
+import pytest
+
+from pyupgrade import _fix_py3_plus
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        # when using open without referencing io we don't need to rewrite
+        'from io import open\n\n'
+        'with open("f.txt") as f:\n'
+        '     print(f.read())\n',
+    ),
+)
+def test_fix_io_open_noop(s):
+    assert _fix_py3_plus(s) == s
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        (
+            'import io\n\n'
+            'with io.open("f.txt", mode="r", buffering=-1, **kwargs) as f:\n'
+            '   print(f.read())\n',
+
+            'import io\n\n'
+            'with open("f.txt", mode="r", buffering=-1, **kwargs) as f:\n'
+            '   print(f.read())\n',
+        ),
+    ),
+)
+def test_fix_io_open(s, expected):
+    assert _fix_py3_plus(s) == expected


### PR DESCRIPTION
Resolves #148 