### PR TITLE
Internally move to min_version over py#-plus

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v0.0.4
+      ref: refs/tags/v0.0.17
 
 jobs:
 - template: job--pre-commit.yml@asottile

--- a/tests/binary_literals_test.py
+++ b/tests/binary_literals_test.py
@@ -27,7 +27,7 @@ from pyupgrade import _fix_tokens
     ),
 )
 def test_binary_literals_noop(s):
-    assert _fix_tokens(s, py3_plus=False) == s
+    assert _fix_tokens(s, min_version=(2, 7)) == s
 
 
 @pytest.mark.parametrize(
@@ -64,4 +64,4 @@ def test_binary_literals_noop(s):
     ),
 )
 def test_binary_literals(s, expected):
-    assert _fix_tokens(s, py3_plus=False) == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected

--- a/tests/encoding_cookie_test.py
+++ b/tests/encoding_cookie_test.py
@@ -7,20 +7,20 @@ from pyupgrade import _fix_tokens
 
 
 @pytest.mark.parametrize(
-    ('s', 'py3_plus'),
+    ('s', 'min_version'),
     (
         pytest.param(
-            '# coding: utf-8\n', False,
+            '# coding: utf-8\n', (2, 7),
             id='cannot remove in py2',
         ),
         pytest.param(
-            '\n\n# coding: utf-8\n', True,
+            '\n\n# coding: utf-8\n', (3,),
             id='only on first two lines',
         ),
     ),
 )
-def test_noop(s, py3_plus):
-    assert _fix_tokens(s, py3_plus=py3_plus) == s
+def test_noop(s, min_version):
+    assert _fix_tokens(s, min_version=min_version) == s
 
 
 @pytest.mark.parametrize(
@@ -45,4 +45,4 @@ def test_noop(s, py3_plus):
     ),
 )
 def test_rewrite(s, expected):
-    assert _fix_tokens(s, py3_plus=True) == expected
+    assert _fix_tokens(s, min_version=(3,)) == expected

--- a/tests/escape_sequences_test.py
+++ b/tests/escape_sequences_test.py
@@ -29,7 +29,7 @@ from pyupgrade import _fix_tokens
     ),
 )
 def test_fix_escape_sequences_noop(s):
-    assert _fix_tokens(s, py3_plus=False) == s
+    assert _fix_tokens(s, min_version=(2, 7)) == s
 
 
 @pytest.mark.parametrize(
@@ -58,4 +58,4 @@ def test_fix_escape_sequences_noop(s):
     ),
 )
 def test_fix_escape_sequences(s, expected):
-    assert _fix_tokens(s, py3_plus=False) == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected

--- a/tests/extra_parens_test.py
+++ b/tests/extra_parens_test.py
@@ -22,7 +22,7 @@ from pyupgrade import _fix_tokens
     ),
 )
 def test_fix_extra_parens_noop(s):
-    assert _fix_tokens(s, py3_plus=False) == s
+    assert _fix_tokens(s, min_version=(2, 7)) == s
 
 
 @pytest.mark.parametrize(
@@ -63,4 +63,4 @@ def test_fix_extra_parens_noop(s):
     ),
 )
 def test_fix_extra_parens(s, expected):
-    assert _fix_tokens(s, py3_plus=False) == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected

--- a/tests/format_literals_test.py
+++ b/tests/format_literals_test.py
@@ -56,7 +56,7 @@ def test_intentionally_not_round_trip(s, expected):
     ),
 )
 def test_format_literals_noop(s):
-    assert _fix_tokens(s, py3_plus=False) == s
+    assert _fix_tokens(s, min_version=(2, 7)) == s
 
 
 @pytest.mark.parametrize(
@@ -104,5 +104,4 @@ def test_format_literals_noop(s):
     ),
 )
 def test_format_literals(s, expected):
-    ret = _fix_tokens(s, py3_plus=False)
-    assert ret == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected

--- a/tests/long_literals_test.py
+++ b/tests/long_literals_test.py
@@ -16,4 +16,4 @@ from pyupgrade import _fix_tokens
     ),
 )
 def test_long_literals(s, expected):
-    assert _fix_tokens(s, py3_plus=False) == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected

--- a/tests/octal_literals_test.py
+++ b/tests/octal_literals_test.py
@@ -17,7 +17,7 @@ from pyupgrade import _fix_tokens
     ),
 )
 def test_noop_octal_literals(s):
-    assert _fix_tokens(s, py3_plus=False) == s
+    assert _fix_tokens(s, min_version=(2, 7)) == s
 
 
 @pytest.mark.parametrize(
@@ -28,4 +28,4 @@ def test_noop_octal_literals(s):
     ),
 )
 def test_fix_octal_literal(s, expected):
-    assert _fix_tokens(s, py3_plus=False) == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected

--- a/tests/raw_unicode_literals_test.py
+++ b/tests/raw_unicode_literals_test.py
@@ -18,9 +18,8 @@ from pyupgrade import _fix_tokens
     ),
 )
 def test_fix_ur_literals(s, expected):
-    ret = _fix_tokens(s, py3_plus=False)
-    assert ret == expected
+    assert _fix_tokens(s, min_version=(2, 7)) == expected
 
 
 def test_fix_ur_literals_gets_fixed_before_u_removed():
-    assert _fix_tokens("ur'\\s\\u2603'", py3_plus=True) == "'\\\\s\\u2603'"
+    assert _fix_tokens("ur'\\s\\u2603'", min_version=(3,)) == "'\\\\s\\u2603'"

--- a/tests/unicode_literals_test.py
+++ b/tests/unicode_literals_test.py
@@ -33,41 +33,40 @@ def test_imports_unicode_literals(s, expected):
 
 
 @pytest.mark.parametrize(
-    ('s', 'py3_plus'),
+    ('s', 'min_version'),
     (
         # Syntax errors are unchanged
-        ('(', False),
+        ('(', (2, 7)),
         # Without py3-plus, no replacements
-        ("u''", False),
+        ("u''", (2, 7)),
         # Regression: string containing newline
-        ('"""with newline\n"""', True),
+        ('"""with newline\n"""', (3,)),
         pytest.param(
             'def f():\n'
             '    return"foo"\n',
-            True,
+            (3,),
             id='Regression: no space between return and string',
         ),
     ),
 )
-def test_unicode_literals_noop(s, py3_plus):
-    assert _fix_tokens(s, py3_plus=py3_plus) == s
+def test_unicode_literals_noop(s, min_version):
+    assert _fix_tokens(s, min_version=min_version) == s
 
 
 @pytest.mark.parametrize(
-    ('s', 'py3_plus', 'expected'),
+    ('s', 'min_version', 'expected'),
     (
         # With py3-plus, it removes u prefix
-        ("u''", True, "''"),
+        ("u''", (3,), "''"),
         # Importing unicode_literals also cause it to remove it
         (
             'from __future__ import unicode_literals\n'
             'u""\n',
-            False,
+            (2, 7),
             'from __future__ import unicode_literals\n'
             '""\n',
         ),
     ),
 )
-def test_unicode_literals(s, py3_plus, expected):
-    ret = _fix_tokens(s, py3_plus=py3_plus)
-    assert ret == expected
+def test_unicode_literals(s, min_version, expected):
+    assert _fix_tokens(s, min_version=min_version) == expected


### PR DESCRIPTION
this will make it potentially easier to implement a `__future__` rewrite