### PR TITLE
Add Python 3.8

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.2.3
+    rev: v2.3.0
     hooks:
     -   id: check-docstring-first
     -   id: check-yaml
@@ -11,11 +11,11 @@ repos:
     -   id: requirements-txt-fixer
     -   id: trailing-whitespace
 -   repo: https://github.com/asottile/setup-cfg-fmt
-    rev: v1.2.1
+    rev: v1.6.0
     hooks:
     -   id: setup-cfg-fmt
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.7
+    rev: 3.7.8
     hooks:
     -   id: flake8
         additional_dependencies: [flake8-typing-imports==1.1.0]
@@ -24,18 +24,18 @@ repos:
     hooks:
     -   id: autopep8
 -   repo: https://github.com/asottile/reorder_python_imports
-    rev: v1.5.0
+    rev: v1.7.0
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v1.3.0
+    rev: v1.4.1
     hooks:
     -   id: add-trailing-comma
 -   repo: https://github.com/asottile/pyupgrade
-    rev: v1.24.1
+    rev: v1.25.0
     hooks:
     -   id: pyupgrade
 -   repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.711
+    rev: v0.730
     hooks:
     -   id: mypy

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,7 +25,7 @@ classifiers =
 py_modules = pyupgrade
 install_requires =
     tokenize-rt>=3.2.0
-    typing; python_version=="2.7"
+    typing;python_version=="2.7"
 python_requires = >=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ classifiers =
     Programming Language :: Python :: 3.5
     Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py36,py37,pypy,pypy3,pre-commit
+envlist = py27,py36,py37,py38,pypy,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
Plus pre-commit updates to include `setup-cfg-fmt`'s https://github.com/asottile/setup-cfg-fmt/pull/22.