### PR TITLE
Fix unsafe yield from rewrite

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
     hooks:
     -   id: reorder-python-imports
 -   repo: https://github.com/asottile/add-trailing-comma
-    rev: v1.3.0
+    rev: v1.5.0
     hooks:
     -   id: add-trailing-comma
 -   repo: https://github.com/asottile/pyupgrade

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1557,7 +1557,7 @@ class FindNamesRefsAfterForLoopVisitor(ast.NodeVisitor):
         self.generic_visit(node)
 
     def visit(self, node):  # type: (ast.AST) -> None
-        super().visit(node)
+        super(FindNamesRefsAfterForLoopVisitor, self).visit(node)
         self._stack_depth += 1
 
 

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1315,6 +1315,10 @@ class FindPy3Plus(ast.NodeVisitor):
 
     visit_FunctionDef = visit_Lambda = _visit_sync_func
 
+    def visit_AsyncFunctionDef(self, node):  # pragma: no cover (py35+)
+        # type: (AsyncFunctionDef) -> None
+        self._visit_func(node)
+
     def _visit_comp(self, node):  # type: (ast.expr) -> None
         self._in_comp += 1
         self.generic_visit(node)

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -58,11 +58,6 @@ if False:  # pragma: no cover (mypy)
         AsyncFunctionDef = ast.AsyncFunctionDef
     else:
         AsyncFunctionDef = ast.stmt
-    SyncOrAsyncFunctionDef = Union[
-        ast.AsyncFunctionDef,
-        ast.FunctionDef,
-        ast.Lambda,
-    ]
 
 _stdlib_parse_format = string.Formatter().parse
 
@@ -1201,7 +1196,7 @@ class FindPy3Plus(ast.NodeVisitor):
         self._class_info_stack = []  # type: List[FindPy3Plus.ClassInfo]
         self._in_comp = 0
         self.super_calls = {}  # type: Dict[Offset, ast.Call]
-        self._current_func = None  # type: Optional[SyncOrAsyncFunctionDef]
+        self._current_func = None  # type: Optional[Union[ast.FunctionDef, ast.Lambda]]  # noqa: E501
         self._for_targets = {}  # type: Dict[Tuple[ast.FunctionDef, str], Offset]  # noqa: E501
         self.yield_from_fors = set()  # type: Set[Offset]
 
@@ -1301,7 +1296,7 @@ class FindPy3Plus(ast.NodeVisitor):
         self._class_info_stack.pop()
 
     def _visit_func(self, node):
-        # type: (SyncOrAsyncFunctionDef) -> None
+        # type: (Union[AsyncFunctionDef, ast.FunctionDef, ast.Lambda]) -> None
         if self._class_info_stack:
             class_info = self._class_info_stack[-1]
             class_info.def_depth += 1

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -61,7 +61,7 @@ if False:  # pragma: no cover (mypy)
     SyncOrAsyncFunctionDef = Union[
         ast.AsyncFunctionDef,
         ast.FunctionDef,
-        ast.Lambda
+        ast.Lambda,
     ]
 
 _stdlib_parse_format = string.Formatter().parse

--- a/tests/super_test.py
+++ b/tests/super_test.py
@@ -112,19 +112,6 @@ def test_fix_super_noop(s):
             '    def f(cls):\n'
             '        super().f()\n',
         ),
-        pytest.param(
-            'class C:\n'
-            '    async def foo(self):\n'
-            '        super(C, self).foo()\n',
-            'class C:\n'
-            '    async def foo(self):\n'
-            '        super().foo()\n',
-            id='super inside async func def',
-            marks=pytest.mark.xfail(
-                sys.version_info < (3, 5),
-                reason='async introduced in python 3.5',
-            ),
-        ),
     ),
 )
 def test_fix_super(s, expected):
@@ -135,19 +122,15 @@ def test_fix_super(s, expected):
     sys.version_info < (3, 5),
     reason='async introduced in python 3.5',
 )
-@pytest.mark.parametrize(
-    ('s', 'expected'),
-    (
-        pytest.param(
-            'class C:\n'
-            '    async def foo(self):\n'
-            '        super(C, self).foo()\n',
-            'class C:\n'
-            '    async def foo(self):\n'
-            '        super().foo()\n',
-            id='super inside async func def',
-        ),
-    ),
-)
-def test_fix_async_super(s, expected):
+def test_fix_async_super():
+    s = (
+        'class C:\n'
+        '    async def foo(self):\n'
+        '        super(C, self).foo()\n'
+    )
+    expected = (
+        'class C:\n'
+        '    async def foo(self):\n'
+        '        super().foo()\n'
+    )
     assert _fix_py3_plus(s) == expected

--- a/tests/super_test.py
+++ b/tests/super_test.py
@@ -129,3 +129,25 @@ def test_fix_super_noop(s):
 )
 def test_fix_super(s, expected):
     assert _fix_py3_plus(s) == expected
+
+
+@pytest.mark.xfail(
+    sys.version_info < (3, 5),
+    reason='async introduced in python 3.5',
+)
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        pytest.param(
+            'class C:\n'
+            '    async def foo(self):\n'
+            '        super(C, self).foo()\n',
+            'class C:\n'
+            '    async def foo(self):\n'
+            '        super().foo()\n',
+            id='super inside async func def',
+        ),
+    ),
+)
+def test_fix_async_super(s, expected):
+    assert _fix_py3_plus(s) == expected

--- a/tests/super_test.py
+++ b/tests/super_test.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 
+import sys
+
 import pytest
 
 from pyupgrade import _fix_py3_plus
@@ -109,6 +111,19 @@ def test_fix_super_noop(s):
             '    @classmethod\n'
             '    def f(cls):\n'
             '        super().f()\n',
+        ),
+        pytest.param(
+            'class C:\n'
+            '    async def foo(self):\n'
+            '        super(C, self).foo()\n',
+            'class C:\n'
+            '    async def foo(self):\n'
+            '        super().foo()\n',
+            id='super inside async func def',
+            marks=pytest.mark.xfail(
+                sys.version_info < (3, 5),
+                reason='async introduced in python 3.5',
+            ),
         ),
     ),
 )

--- a/tests/yield_from_test.py
+++ b/tests/yield_from_test.py
@@ -119,16 +119,6 @@ from pyupgrade import targets_same
         ),
         pytest.param(
             'def f():\n'
-            '    for x in z:\n'
-            '        yield x\n'
-            '    x = None\n',
-            'def f():\n'
-            '    yield from z\n'
-            '    x = None\n',
-            id='loop variable assigned after the loop',
-        ),
-        pytest.param(
-            'def f():\n'
             '    print(x)\n'
             '    for x in z:\n'
             '        yield x\n',
@@ -169,6 +159,7 @@ from pyupgrade import targets_same
             '        print(y)\n',
             id='multiple for loops',
         ),
+
     ),
 )
 def test_fix_yield_from(s, expected):
@@ -275,6 +266,36 @@ def test_fix_async_yield_from(s, expected):
             '        yield x, y\n'
             '    print(x)\n',
             id='multiple loop variables referenced after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    async def g():\n'
+            '        for y in z:\n'
+            '            yield y\n'
+            '    return g\n',
+            id='for loop inside async func, which is inside sync',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    x = None\n',
+            id='loop variable assigned after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    x = None'
+            '    print(x)\n',
+            id='loop variable assigned and referenced after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    x += 1',
+            id='augmented assignment after the loop',
         ),
     ),
 )

--- a/tests/yield_from_test.py
+++ b/tests/yield_from_test.py
@@ -252,10 +252,6 @@ def test_fix_async_yield_from(s, expected):
             id='yield outside function',
         ),
         pytest.param(
-            'lambda: [(yield x) for x in z]',
-            id='yield inside lambda',
-        ),
-        pytest.param(
             'def f():\n'
             '    x = None\n'
             '    for x in z:\n'

--- a/tests/yield_from_test.py
+++ b/tests/yield_from_test.py
@@ -184,6 +184,48 @@ def test_fix_async_yield_from(s, expected):
         '        yield x\n'
         '    else:\n'
         '        print("boom!")\n',
+        pytest.param(
+            'for x in z:\n'
+            '    yield x\n',
+            id='yield outside function',
+        ),
+        pytest.param(
+            'lambda: [(yield x) for x in z]',
+            id='yield inside lambda',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    x = None\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    print(x)\n',
+            id='loop variable referenced after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    x = None\n'
+            '    for x, y in z:\n'
+            '        yield x, y\n'
+            '    x = True\n',
+            id='loop variable reassigned after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    def b():\n'
+            '        x = None\n'
+            '        for x in z:\n'
+            '            yield x\n'
+            '         print(x)\n',
+            id='loop variable referenced after the loop, nested funcs',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    x = None\n'
+            '    for x, y in z:\n'
+            '        yield x, y\n'
+            '    print(x)\n',
+            id='multiple loop variables referenced after the loop',
+        ),
     ),
 )
 def test_fix_yield_from_noop(s):

--- a/tests/yield_from_test.py
+++ b/tests/yield_from_test.py
@@ -107,6 +107,68 @@ from pyupgrade import targets_same
             'def g():\n'
             '    print(3)',
         ),
+        pytest.param(
+            'def f():\n'
+            '    x = None\n'
+            '    for x in z:\n'
+            '        yield x\n',
+            'def f():\n'
+            '    x = None\n'
+            '    yield from z\n',
+            id='loop variable assigned before the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    x = None\n',
+            'def f():\n'
+            '    yield from z\n'
+            '    x = None\n',
+            id='loop variable assigned after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    print(x)\n'
+            '    for x in z:\n'
+            '        yield x\n',
+            'def f():\n'
+            '    print(x)\n'
+            '    yield from z\n',
+            id='loop variable referenced before the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    print(w)\n'
+            '    for x in z:\n'
+            '        yield x\n',
+            'def f():\n'
+            '    print(w)\n'
+            '    yield from z\n',
+            id='non-loop variable referenced before the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    print(w)\n',
+            'def f():\n'
+            '    yield from z\n'
+            '    print(w)\n',
+            id='non-loop variable referenced after the loop',
+        ),
+        pytest.param(
+            'def f():\n'
+            '    for x in z:\n'
+            '        yield x\n'
+            '    for y in w:\n'
+            '        print(y)\n',
+            'def f():\n'
+            '    yield from z\n'
+            '    for y in w:\n'
+            '        print(y)\n',
+            id='multiple for loops',
+        ),
     ),
 )
 def test_fix_yield_from(s, expected):
@@ -200,14 +262,6 @@ def test_fix_async_yield_from(s, expected):
             '        yield x\n'
             '    print(x)\n',
             id='loop variable referenced after the loop',
-        ),
-        pytest.param(
-            'def f():\n'
-            '    x = None\n'
-            '    for x, y in z:\n'
-            '        yield x, y\n'
-            '    x = True\n',
-            id='loop variable reassigned after the loop',
         ),
         pytest.param(
             'def f():\n'


### PR DESCRIPTION
Fixes #216.

Prevents rewrite `for-loop yield` if a loop variable referenced after the loop.

Also, it fixes along the way the case with yield outside the function. Now `pyupgrade` doesn't rewrite it:
```bash
# before
$ echo "for x in y: yield x" | pyupgrade - --py3-plus
yield from y

# after
$ echo "for x in y: yield x" | pyupgrade - --py3-plus
for x in y: yield x
```
<sup>I don't know is it intentional behavior or not. Please, inform if it is.</sup>

Additionally, I've added a test for `lambda yield` (weird but syntactically possible), since there is `Union[ast.FunctionDef, ast.Lambda]`.


