### PR TITLE
Add failing test for py27 ast.parse(<unicode>)

### DIFF
--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -51,6 +51,13 @@ def test_main_non_utf8_bytes(tmpdir, capsys):
     assert out == '{} is non-utf-8 (not supported)\n'.format(f.strpath)
 
 
+def test_main_py27_syntaxerror_coding(tmpdir):
+    f = tmpdir.join('f.py')
+    f.write('# -*- coding: utf-8\nset((1, 2))\n')
+    assert main((f.strpath,)) == 1
+    assert f.read() == '# -*- coding: utf-8\n{1, 2}\n'
+
+
 def test_keep_percent_format(tmpdir):
     f = tmpdir.join('f.py')
     f.write('"%s" % (1,)')


### PR DESCRIPTION
@isidentical pointed out that [this](https://github.com/asottile/pyupgrade/blob/4fb4dd08da682c860c7e376dfa350c588843c2c0/pyupgrade.py#L108) looked strange.  I noticed that I didn't have a test failing when I removed `.encode('UTF-8')` so here's one

```
=================================== FAILURES ===================================
______________________ test_main_py27_syntaxerror_coding _______________________

tmpdir = local('/tmp/pytest-of-asottile/pytest-4/test_main_py27_syntaxerror_cod0')

    def test_main_py27_syntaxerror_coding(tmpdir):
        f = tmpdir.join('f.py')
        f.write('# -*- coding: utf-8\nset((1, 2))\n')
>       assert main((f.strpath,)) == 1
E       AssertionError: assert 0 == 1
E        +  where 0 = main(('/tmp/pytest-of-asottile/pytest-4/test_main_py27_syntaxerror_cod0/f.py',))

tests/main_test.py:57: AssertionError
```