### PR TITLE
Rewrite format literals containing \N escapes

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -2422,8 +2422,11 @@ def _fix_py36_plus(contents_text: str) -> str:
             if tokens[end].line != token.line:
                 continue
 
-            tokens[i] = token._replace(src=_to_fstring(token.src, node))
-            del tokens[i + 1:end + 1]
+            try:
+                tokens[i] = token._replace(src=_to_fstring(token.src, node))
+                del tokens[i + 1:end + 1]
+            except KeyError:
+                pass
         elif token.offset in visitor.named_tuples and token.name == 'NAME':
             call = visitor.named_tuples[token.offset]
             types: Dict[str, ast.expr] = {

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -617,8 +617,6 @@ def _fix_format_literal(tokens: List[Token], end: int) -> None:
                     spec is not None and '{' not in spec
             ):
                 last_int += 1
-            elif fmtkey is None and spec is None:
-                pass
             else:
                 return
 

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -2229,7 +2229,7 @@ def _to_fstring(src: str, call: ast.Call) -> str:
     parts = []
     i = 0
     for s, name, spec, conv in parse_format('f' + src):
-        if name is not None:
+        if name is not None and not s.endswith(r'\N'):  # skip \N escape seqs
             k, dot, rest = name.partition('.')
             name = ''.join((params[k or str(i)], dot, rest))
             if not k:  # named and auto params can be in different orders
@@ -2257,10 +2257,6 @@ def _fix_fstrings(contents_text: str) -> str:
     for i, token in reversed_enumerate(tokens):
         node = visitor.found.get(token.offset)
         if node is None:
-            continue
-
-        # TODO: handle \N escape sequences
-        if r'\N' in token.src:
             continue
 
         paren = i + 3

--- a/tests/format_literals_test.py
+++ b/tests/format_literals_test.py
@@ -49,7 +49,7 @@ def test_intentionally_not_round_trip(s, expected):
         "'{' '0}'.format(1)",
         # comment looks like placeholder but is not!
         '("{0}" # {1}\n"{2}").format(1, 2, 3)',
-        # TODO: this works by accident (extended escape treated as placeholder)
+        # this works by accident (extended escape treated as placeholder)
         r'"\N{snowman} {}".format(1)',
     ),
 )
@@ -99,6 +99,8 @@ def test_format_literals_noop(s):
         ),
         # parenthesized string literals
         ('("{0}").format(1)', '("{}").format(1)'),
+        # extended unicode escapes
+        (r'"\N{snowman} {0}".format(1)', r'"\N{snowman} {}".format(1)'),
     ),
 )
 def test_format_literals(s, expected):

--- a/tests/fstrings_test.py
+++ b/tests/fstrings_test.py
@@ -28,6 +28,8 @@ from pyupgrade import _fix_fstrings
         '"{a.a[b]}".format(a=a)',
         # not enough placeholders / placeholders missing
         '"{}{}".format(a)', '"{a}{b}".format(a=a)',
+        # invald \N escape
+        r'"{} \\N{snowman}".format(a)',
     ),
 )
 def test_fix_fstrings_noop(s):
@@ -49,6 +51,7 @@ def test_fix_fstrings_noop(s):
         ('"{}{{}}{}".format(escaped, y)', 'f"{escaped}{{}}{y}"'),
         ('"{}{b}{}".format(a, c, b=b)', 'f"{a}{b}{c}"'),
         (r'"{} \N{snowman}".format(a)', r'f"{a} \N{snowman}"'),
+        (r'"\\N{snowman}".format(snowman=snowman)', r'f"\\N{snowman}"'),
         # TODO: poor man's f-strings?
         # '"{foo}".format(**locals())'
     ),

--- a/tests/fstrings_test.py
+++ b/tests/fstrings_test.py
@@ -26,8 +26,6 @@ from pyupgrade import _fix_fstrings
         '"{:{}}".format(x, y)',
         '"{a[b]}".format(a=a)',
         '"{a.a[b]}".format(a=a)',
-        # TODO: handle \N escape sequences
-        r'"\N{snowman} {}".format(a)',
         # not enough placeholders / placeholders missing
         '"{}{}".format(a)', '"{a}{b}".format(a=a)',
     ),
@@ -50,6 +48,7 @@ def test_fix_fstrings_noop(s):
         ('"hello {}!".format(name)', 'f"hello {name}!"'),
         ('"{}{{}}{}".format(escaped, y)', 'f"{escaped}{{}}{y}"'),
         ('"{}{b}{}".format(a, c, b=b)', 'f"{a}{b}{c}"'),
+        (r'"{} \N{snowman}".format(a)', r'f"{a} \N{snowman}"'),
         # TODO: poor man's f-strings?
         # '"{foo}".format(**locals())'
     ),

--- a/tests/percent_format_test.py
+++ b/tests/percent_format_test.py
@@ -176,8 +176,6 @@ def test_simplify_conversion_flag(s, expected):
         '"%(and)s" % {"and": 2}',
         # invalid string formats
         '"%" % {}', '"%(hi)" % {}', '"%2" % {}',
-        # TODO: handle \N escape sequences
-        r'"%s \N{snowman}" % (a,)',
     ),
 )
 def test_percent_format_noop(s):
@@ -220,6 +218,11 @@ def test_percent_format_noop_if_bug_16806():
         # dict
         ('"%(k)s" % {"k": "v"}', '"{k}".format(k="v")'),
         ('"%(to_list)s" % {"to_list": []}', '"{to_list}".format(to_list=[])'),
+        # Leave \N escape sequences alone
+        (
+            r'"%s {build a} \N{snowman}" % (a,)',
+            r'"{} {{build a}} \N{snowman}".format(a)',
+        ),
     ),
 )
 def test_percent_format(s, expected):

--- a/tests/percent_format_test.py
+++ b/tests/percent_format_test.py
@@ -223,6 +223,7 @@ def test_percent_format_noop_if_bug_16806():
             r'"%s {build a} \N{snowman}" % (a,)',
             r'"{} {{build a}} \N{snowman}".format(a)',
         ),
+        (r'"%s \\N{snowman}" % (a,)', r'"{} \\N{{snowman}}".format(a)'),
     ),
 )
 def test_percent_format(s, expected):


### PR DESCRIPTION
This is my attempt at fixing #280 (I started it for #278).

It's based on current parser behaviour:
- for the `%` encoding we let it convert to `\N{{snowman}}` and fix it afterwards
- for the `.format`, the source will end with `\N` (with name being `snowman`). We can reuse the original format for this.