### PR TITLE
Use original source when building f-strings

### DIFF
--- a/pyupgrade/_plugins/oserror_aliases.py
+++ b/pyupgrade/_plugins/oserror_aliases.py
@@ -62,7 +62,7 @@ def _fix_oserror_except(
     if len(unique_args) > 1:
         joined = '({})'.format(', '.join(unique_args))
     elif tokens[start - 1].name != 'UNIMPORTANT_WS':
-        joined = ' {}'.format(unique_args[0])
+        joined = f' {unique_args[0]}'
     else:
         joined = unique_args[0]
 

--- a/tests/features/fstrings_test.py
+++ b/tests/features/fstrings_test.py
@@ -30,6 +30,10 @@ from pyupgrade._main import _fix_py36_plus
         r'"\N{snowman} {}".format(a)',
         # not enough placeholders / placeholders missing
         '"{}{}".format(a)', '"{a}{b}".format(a=a)',
+        # backslashes and quotes cannot nest
+        r'''"{}".format(a['\\'])''',
+        '"{}".format(a["b"])',
+        "'{}'.format(a['b'])",
     ),
 )
 def test_fix_fstrings_noop(s):
@@ -50,6 +54,7 @@ def test_fix_fstrings_noop(s):
         ('"hello {}!".format(name)', 'f"hello {name}!"'),
         ('"{}{{}}{}".format(escaped, y)', 'f"{escaped}{{}}{y}"'),
         ('"{}{b}{}".format(a, c, b=b)', 'f"{a}{b}{c}"'),
+        ('"{}".format(0x0)', 'f"{0x0}"'),
         # TODO: poor man's f-strings?
         # '"{foo}".format(**locals())'
     ),


### PR DESCRIPTION
Working at the AST level meant we only handled a small subset of Python when generating f-strings. By extracting the original code as a string we can handle many more cases.

~~A disadvantage of this approach is that it requires Python ≥ 3.8 for `ast.expr.end_lineno`, `ast.expr.end_col_offset`.~~ This now uses the token stream like everything else, avoiding that requirement.