### PR TITLE
Fix syntax error in NamedTuple example

### DIFF
--- a/README.md
+++ b/README.md
@@ -413,7 +413,7 @@ Availability:
 
 ```python
 # input
-NT = typing.NamedTuple('NT', [('a': int, 'b': Tuple[str, ...])])
+NT = typing.NamedTuple('NT', [('a', int), ('b', Tuple[str, ...])])
 
 D1 = typing.TypedDict('D1', a=int, b=str)
 


### PR DESCRIPTION
The backward-compatible usage of NamedTuple expects a list of 2-tuples, not a list of type annotated strings.

```
$ python3 -c "typing.NamedTuple('NT', [('a': int, 'b': Tuple[str, ...])])"
  File "<string>", line 1
    typing.NamedTuple('NT', [('a': int, 'b': Tuple[str, ...])])
                                 ^
SyntaxError: invalid syntax
```

See also https://docs.python.org/3/library/typing.html#typing.NamedTuple