### PR TITLE
Ensure keys are non-keyword identifiers for TypedDict / NamedTuple

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -2449,6 +2449,7 @@ class FindPy36Plus(ast.NodeVisitor):
                         isinstance(tup, ast.Tuple) and
                         len(tup.elts) == 2 and
                         isinstance(tup.elts[0], ast.Str) and
+                        tup.elts[0].s.isidentifier() and
                         tup.elts[0].s not in _KEYWORDS
                         for tup in node.value.args[1].elts
                     )
@@ -2475,7 +2476,9 @@ class FindPy36Plus(ast.NodeVisitor):
                     isinstance(node.value.args[1], ast.Dict) and
                     node.value.args[1].keys and
                     all(
-                        isinstance(k, ast.Str)
+                        isinstance(k, ast.Str) and
+                        k.s.isidentifier() and
+                        k.s not in _KEYWORDS
                         for k in node.value.args[1].keys
                     )
             ):

--- a/tests/typing_named_tuple_test.py
+++ b/tests/typing_named_tuple_test.py
@@ -42,6 +42,10 @@ from pyupgrade import _fix_py36_plus
             id='uses keyword',
         ),
         pytest.param(
+            'C = typing.NamedTuple("C", [("not-ok", int)])',
+            id='uses non-identifier',
+        ),
+        pytest.param(
             'C = typing.NamedTuple("C", *types)',
             id='NamedTuple starargs',
         ),

--- a/tests/typing_typed_dict_test.py
+++ b/tests/typing_typed_dict_test.py
@@ -20,6 +20,14 @@ from pyupgrade import _fix_py36_plus
             id='key is not a string',
         ),
         pytest.param(
+            'D = typing.TypedDict("D", {"a-b": str})',
+            id='key is not an identifier',
+        ),
+        pytest.param(
+            'D = typing.TypedDict("D", {"class": str})',
+            id='key is a keyword',
+        ),
+        pytest.param(
             'D = typing.TypedDict("D", {**d, "a": str})',
             id='dictionary splat operator',
         ),


### PR DESCRIPTION
Resolves #322 