### PR TITLE
Include tests in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft tests


### PR DESCRIPTION
Includes the tests in the source tarball, which is mostly for dev and packaging purpose. Tests are needed/useful for further packaging.

The tests will not be included in the bdist_wheel packages.