### PR TITLE
Rewrite `six.reraise(*sys.exc_info())`

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,6 +341,7 @@ six.get_function_defaults(fn)           # fn.__defaults__
 six.get_function_globals(fn)            # fn.__globals__
 six.raise_from(exc, exc_from)           # raise exc from exc_from
 six.reraise(tp, exc, tb)                # raise exc.with_traceback(tb)
+six.reraise(*sys.exc_info())            # raise
 six.assertCountEqual(self, a1, a2)      # self.assertCountEqual(a1, a2)
 six.assertRaisesRegex(self, e, r, fn)   # self.assertRaisesRegex(e, r, fn)
 six.assertRegex(self, s, r)             # self.assertRegex(s, r)

--- a/tests/six_test.py
+++ b/tests/six_test.py
@@ -225,6 +225,17 @@ def test_fix_six_noop(s):
             'raise exc.with_traceback(None)\n',
         ),
         (
+            'six.reraise(*sys.exc_info())\n',
+            'raise\n',
+        ),
+        (
+            'from sys import exc_info\n'
+            'six.reraise(*exc_info())\n',
+
+            'from sys import exc_info\n'
+            'raise\n',
+        ),
+        (
             'from six import raise_from\n'
             'raise_from(exc, exc_from)\n',
 


### PR DESCRIPTION
I was running pyupgrade and in a few repos it would remove every instance of six except his one. I figured this would be straightforward to rewrite as well. It's not a py3+ rewrite (so feel free to close) but but it would help remove more six code.