### PR TITLE
fixed #349 - parenthesis for BoolOps

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1536,12 +1536,12 @@ class FindPy3Plus(ast.NodeVisitor):
         elif self._is_six(node.func, ('b', 'ensure_binary')):
             self.six_b.add(_ast_to_offset(node))
         elif self._is_six(node.func, SIX_CALLS) and not _starargs(node):
-            needs_parenthesis = node.args and isinstance(
+            offset = _ast_to_offset(node)
+
+            if node.args and isinstance(
                 node.args[0],
                 (ast.BoolOp, ast.IfExp, ast.BinOp, ast.GeneratorExp),
-            )
-            offset = _ast_to_offset(node)
-            if needs_parenthesis:
+            ):
                 self.six_calls_parenthesized[offset] = node
             else:
                 self.six_calls[offset] = node

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1539,9 +1539,9 @@ class FindPy3Plus(ast.NodeVisitor):
         elif self._is_six(node.func, ('b', 'ensure_binary')):
             self.six_b.add(_ast_to_offset(node))
         elif self._is_six(node.func, SIX_CALLS) and not _starargs(node):
-            needs_parenthesis = (
-                node.args and
-                isinstance(node.args[0], ast.BoolOp)
+            needs_parenthesis = node.args and isinstance(
+                node.args[0],
+                (ast.BoolOp, ast.IfExp, ast.BinOp, ast.GeneratorExp),
             )
             six_calls = (
                 self.six_calls_parenthesized

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1543,11 +1543,11 @@ class FindPy3Plus(ast.NodeVisitor):
                 node.args[0],
                 (ast.BoolOp, ast.IfExp, ast.BinOp, ast.GeneratorExp),
             )
-            six_calls = (
-                self.six_calls_parenthesized
-                if needs_parenthesis else self.six_calls
-            )
-            six_calls[_ast_to_offset(node)] = node
+            offset = _ast_to_offset(node)
+            if needs_parenthesis:
+                self.six_calls_parenthesized[offset] = node
+            else:
+                self.six_calls[offset] = node
         elif (
                 isinstance(node.func, ast.Name) and
                 node.func.id == 'next' and

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -2039,7 +2039,10 @@ def _replace_yield(tokens: List[Token], i: int) -> None:
 
 
 def _replace_six_calls(
-    tokens: List[Token], call: ast.Call, i: int,
+    *,
+    tokens: List[Token],
+    call: ast.Call,
+    i: int,
     needs_parenthesis: bool = False,
 ) -> None:
     j = _find_open_paren(tokens, i)
@@ -2186,10 +2189,12 @@ def _fix_py3_plus(
             _replace_call(tokens, i, end, func_args, template)
         elif token.offset in visitor.six_calls:
             call = visitor.six_calls[token.offset]
-            _replace_six_calls(tokens, call, i)
+            _replace_six_calls(tokens=tokens, call=call, i=i)
         elif token.offset in visitor.six_calls_parenthesized:
             call = visitor.six_calls_parenthesized[token.offset]
-            _replace_six_calls(tokens, call, i, needs_parenthesis=True)
+            _replace_six_calls(
+                tokens=tokens, call=call, i=i, needs_parenthesis=True,
+            )
         elif token.offset in visitor.six_raise_from:
             j = _find_open_paren(tokens, i)
             func_args, end = _parse_call_args(tokens, j)

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1538,9 +1538,12 @@ class FindPy3Plus(ast.NodeVisitor):
         elif self._is_six(node.func, SIX_CALLS) and not _starargs(node):
             offset = _ast_to_offset(node)
 
-            if node.args and isinstance(
-                node.args[0],
-                (ast.BoolOp, ast.IfExp, ast.BinOp, ast.GeneratorExp),
+            if (
+                    node.args and
+                    isinstance(
+                        node.args[0],
+                        (ast.BoolOp, ast.IfExp, ast.BinOp, ast.GeneratorExp),
+                    )
             ):
                 self.six_calls_parenthesized[offset] = node
             else:

--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -1539,6 +1539,7 @@ class FindPy3Plus(ast.NodeVisitor):
             offset = _ast_to_offset(node)
 
             if (
+                    not self._is_six(node.func, ('int2byte',)) and
                     node.args and
                     isinstance(
                         node.args[0],

--- a/tests/six_test.py
+++ b/tests/six_test.py
@@ -388,19 +388,24 @@ def test_fix_six_noop(s):
             id='six.itervalues with boolean logic inside call',
         ),
         pytest.param(
-            'six.iterkeys({} if True else {})\n',
-            '({} if True else {}).keys()\n',
-            id='six.itervalues with if-expression inside call',
+            'six.iteritems({} | {})\n',
+            '({} | {}).items()\n',
+            id='six.iteritems with merge operator inside call',
         ),
         pytest.param(
-            'six.iteritems({} for _ in "")\n',
-            '({} for _ in "").items()\n',
-            id='six.itervalues with generator expression inside call',
+            'six.iterkeys({} if True else {})\n',
+            '({} if True else {}).keys()\n',
+            id='six.iterkeys with if-expression inside call',
         ),
         pytest.param(
             'six.int2byte(1 & 1)\n',
-            'bytes(((1 & 1),))\n',
-            id='six.itervalues with binary logic inside call',
+            'bytes((1 & 1,))\n',
+            id='six.int2byte with binary logic inside call',
+        ),
+        pytest.param(
+            'six.u("a" for _ in "b")\n',
+            '("a" for _ in "b")\n',
+            id='six.u with generator expression inside call',
         ),
     ),
 )

--- a/tests/six_test.py
+++ b/tests/six_test.py
@@ -385,7 +385,22 @@ def test_fix_six_noop(s):
         pytest.param(
             'six.itervalues({} or {})\n',
             '({} or {}).values()\n',
-            id='six.itervalues with logic inside call',
+            id='six.itervalues with boolean logic inside call',
+        ),
+        pytest.param(
+            'six.iterkeys({} if True else {})\n',
+            '({} if True else {}).keys()\n',
+            id='six.itervalues with if-expression inside call',
+        ),
+        pytest.param(
+            'six.iteritems({} for _ in "")\n',
+            '({} for _ in "").items()\n',
+            id='six.itervalues with generator expression inside call',
+        ),
+        pytest.param(
+            'six.int2byte(1 & 1)\n',
+            'bytes(((1 & 1),))\n',
+            id='six.itervalues with binary logic inside call',
         ),
     ),
 )

--- a/tests/six_test.py
+++ b/tests/six_test.py
@@ -382,6 +382,11 @@ def test_fix_six_noop(s):
             'print(next(iter({1:2}.values())))\n',
             id='six.itervalues inside next(...)',
         ),
+        pytest.param(
+            'six.itervalues({} or {})\n',
+            '({} or {}).values()\n',
+            id='six.itervalues with logic inside call',
+        ),
     ),
 )
 def test_fix_six(s, expected):


### PR DESCRIPTION
Implemented as you wished, but the `needs_parenthesis` check right now only looks for `BoolOp`, `expr` wasn't the right thing.