### PR TITLE
Add `--check` option

### DIFF
--- a/pyupgrade.py
+++ b/pyupgrade.py
@@ -2717,7 +2717,9 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     if args.min_version >= (3, 6):
         contents_text = _fix_py36_plus(contents_text)
 
-    if filename == '-':
+    if args.check:
+        print(f'Would rewrite {filename}', file=sys.stderr)
+    elif filename == '-':
         print(contents_text, end='')
     elif contents_text != contents_text_orig:
         print(f'Rewriting {filename}', file=sys.stderr)
@@ -2733,6 +2735,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
+    parser.add_argument('--check', action='store_true')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -183,6 +183,16 @@ def test_noop_token_error(tmpdir):
     assert main((f.strpath, '--py36-plus')) == 0
 
 
+def test_main_check(tmpdir, capsys):
+    original = 'x = set((1, 2, 3))\n'
+    f = tmpdir.join('f.py')
+    f.write(original)
+    assert main((f.strpath, '--check')) == 1
+    out, err = capsys.readouterr()
+    assert err == f'Would rewrite {f.strpath}\n'
+    assert f.read() == original
+
+
 def test_main_exit_zero_even_if_changed(tmpdir):
     f = tmpdir.join('t.py')
     f.write('set((1, 2))\n')


### PR DESCRIPTION
This adds a `pyupgrade --check` option that does only check but not
rewrite the given files. If a file would be rewritten, a message is
printed to `stderr`.

Alternatives
------------

1. Using [pre-commit](https://pre-commit.com/)

Instead of adding this option, the user could use
`pre-commit run --all-files --show-diff-on-failure`.

2. Querying the version control system

Instead of adding this option, the user could let `pyupgrade` change the
files and use `git` or a similar tool to determine if something has
changed. After that the version control system could revert the changes.

3. Writing an orchestration script

Instead of adding this option, the user could write their own
orchestration script that would open and read the file to be checked and
pass them via `stdin` to `pyupgrade`. It could then compare the output
to the original content.

Why this is useful
------------------

A `--check` option is useful whenever one wants to enforce that all code
is compliant to a certain standard. This applies to `git` `pre-commit`
hooks, but also automated tests (especially run in a CI context).

Adding this option provides a significant benefit while adding minimal
additional maintenaince burden. The alternatives mentioned above all
have their own shortcomings:

1. In certain restricted environments it is not possible to load
arbitrary code during a CI run. Especially not from untrusted sources
(`pypi`, `npm` or even github). Additionally in some environments the
user might want to lock down exact versions of tools to be used. While
possible with `pre-commit`, it requires quite some overhead to install
and configure `pre-commit` and create and maintain a local
hook-repository just to be able to run `pyupgrade` as part of an
automated CI test.

2. This is simply not a good idea when it comes to parallel test
execution when we imagine that multiple tools modify files.

3. This is an actual alternative with two problems: It requires every
user to write this orchestration themselves while providing a `--check`
option is minimally intrusive. It requires a `pyupgrade` invocation for
every file to be checked. This can become quite costly in environments
with many python files.

Alternative implementation
--------------------------

Instead of just printing the filename that would be rewritten, the tool
could also print a diff that informs the user about the changes to be
made. This idea was discarded as it introduces a higher maintenaince
burden.

```python
import difflib

print(
    '\n'.join(
        difflib.unified_diff(
            contents_text_orig.splitlines(),
            contents_text.splitlines(),
            fromfile=f'a/{filename}',
            tofile=f'b/{filename}',
        )
    )
)
```

Related
-------

- Add --check option #210
- Feature request: dry-run option #258
- Add --check flag #310
- Provide better options to integrate with CI #356