### PR TITLE
Document correct minimum version for PEP 604

### DIFF
--- a/README.md
+++ b/README.md
@@ -495,7 +495,7 @@ Availability:
 
 Availability:
 - File imports `from __future__ import annotations`
-- `--py39-plus` is passed on the commandline.
+- `--py310-plus` is passed on the commandline.
 
 ```diff
 -def f() -> Optional[str]:


### PR DESCRIPTION
https://github.com/asottile/pyupgrade/blob/master/pyupgrade/_plugins/typing_pep604.py#L90

Thanks for this great tool!