### PR TITLE
Remove future annotations import with --py310-plus

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,7 @@ Availability:
 - `--py3-plus` will also remove `absolute_import` / `division` /
   `print_function` / `unicode_literals`
 - `--py37-plus` will also remove `generator_stop`
+- `--py310-plus` will also remove `annotations`
 
 ```diff
 -from __future__ import with_statement

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -390,7 +390,7 @@ def _build_import_removals() -> Dict[Version, Dict[str, Tuple[str, ...]]]:
         ((3, 7), ('generator_stop',)),
         ((3, 8), ()),
         ((3, 9), ()),
-        ((3, 10), ()),
+        ((3, 10), ('annotations',)),
     )
 
     prev: Tuple[str, ...] = ()

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -179,6 +179,16 @@ def test_py38_plus_removes_no_arg_decorators(tmpdir):
     )
 
 
+def test_py310_plus_removes_future_annotations(tmpdir):
+    f = tmpdir.join('f.py')
+    f.write('from __future__ import annotations\nx = 1\n')
+    assert main((f.strpath,)) == 0
+    assert main((f.strpath, '--py3-plus')) == 0
+    assert main((f.strpath, '--py39-plus')) == 0
+    assert main((f.strpath, '--py310-plus')) == 1
+    assert f.read() == 'x = 1\n'
+
+
 def test_noop_token_error(tmpdir):
     f = tmpdir.join('f.py')
     f.write(


### PR DESCRIPTION
This PR adds `from __future__ import annotations` to the list of imports that should be removed (if `--py310-plus` is specified).

https://docs.python.org/3.9/library/__future__.html
https://bugs.python.org/issue38605