### PR TITLE
Add opt-out for conversion of str.encode('utf-8') to str.encode()

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,9 @@ ur'\U0001f643'  # u'\U0001f643'
 
 ### `.encode()` to bytes literals
 
+Availability:
+- Unless `--keep-encoding` is passed.
+
 ```python
 'foo'.encode()           # b'foo'
 'foo'.encode('ascii')    # b'foo'

--- a/README.md
+++ b/README.md
@@ -201,6 +201,7 @@ str("foo")  # "foo"
 
 Availability:
 - `--py3-plus` is passed on the commandline.
+- Unless `--keep-encoding` is passed.
 
 ```python
 "foo".encode("utf-8")  # "foo".encode()

--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -30,6 +30,7 @@ class Settings(NamedTuple):
     keep_percent_format: bool = False
     keep_mock: bool = False
     keep_runtime_typing: bool = False
+    keep_encoding: bool = False
 
 
 class State(NamedTuple):

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -832,6 +832,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
             keep_percent_format=args.keep_percent_format,
             keep_mock=args.keep_mock,
             keep_runtime_typing=args.keep_runtime_typing,
+            keep_encoding=args.keep_encoding,
         ),
     )
     contents_text = _fix_tokens(contents_text, min_version=args.min_version)
@@ -858,6 +859,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
     parser.add_argument('--keep-runtime-typing', action='store_true')
+    parser.add_argument('--keep-encoding', action='store_true')
     parser.add_argument(
         '--py3-plus', '--py3-only',
         action='store_const', dest='min_version', default=(2, 7), const=(3,),

--- a/pyupgrade/_plugins/default_encoding.py
+++ b/pyupgrade/_plugins/default_encoding.py
@@ -29,6 +29,7 @@ def visit_Call(
         parent: ast.AST,
 ) -> Iterable[Tuple[Offset, TokenFunc]]:
     if (
+            not state.settings.keep_encoding and
             state.settings.min_version >= (3,) and
             isinstance(node.func, ast.Attribute) and
             isinstance(node.func.value, ast.Str) and

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -91,6 +91,16 @@ def test_keep_mock(tmpdir):
     assert f.read() == 'from unittest.mock import patch\n'
 
 
+def test_keep_encoding(tmpdir):
+    f = tmpdir.join('f.py')
+    code = '"Björk Guðmundsdóttir".encode("utf-8")'
+    f.write(code)
+    assert main((f.strpath, '--py3-plus', '--keep-encoding')) == 0
+    assert f.read() == code
+    assert main((f.strpath, '--py3-plus')) == 1
+    assert f.read() == '"Björk Guðmundsdóttir".encode()'
+
+
 def test_py3_plus_argument_unicode_literals(tmpdir):
     f = tmpdir.join('f.py')
     f.write('u""')


### PR DESCRIPTION
pip does not want this https://github.com/pypa/pip/pull/9766#discussion_r606243093