### PR TITLE
Drop universal wheel declaration

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,6 @@ exclude =
 console_scripts =
     pyupgrade = pyupgrade._main:main
 
-[bdist_wheel]
-universal = True
-
 [coverage:run]
 plugins = covdefaults
 


### PR DESCRIPTION
This project supports Python 3 only now so the wheel should not be marked as universally supporting Pythons 2 and 3.