### PR TITLE
fix: Indicate wheels are Python 3 only and not universal

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -35,9 +35,6 @@ exclude =
 console_scripts =
     pyupgrade = pyupgrade._main:main
 
-[bdist_wheel]
-universal = True
-
 [coverage:run]
 plugins = covdefaults
 


### PR DESCRIPTION
Hi. :wave: I figured this is a small enough thing that I'd just open a PR, but apologies in advance if you would have preferred an Issue first.

The 'universal' setting [means that the wheels are Python 2 and Python 3 compatible](https://wheel.readthedocs.io/en/stable/user_guide.html#building-wheels), but pyupgrade is Python 3 only (:rocket:). This (indicating universal) doesn't do anything bad but it means that the naming of the wheels on PyPI doesn't reflect their nature.

Example:

For pyupgrade `v2.15.0`, the wheel is named `pyupgrade-2.15.0-py2.py3-none-any.whl` and has a listed Python version of
`py2.py3`

[![pyupgrade](https://user-images.githubusercontent.com/5142394/118216342-f5352080-b438-11eb-9f81-9256eaaf17e7.png)](https://pypi.org/project/pyupgrade/2.15.0/#files)

This change will mean the future releases will get named like `pyupgrade-2.15.0-py3-none-any.whl`.

c.f. https://github.com/scikit-hep/pyhf/pull/1295 for another example.