### PR TITLE
Accept directories as arguments and recurse through them

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,15 @@ Sample `.pre-commit-config.yaml`:
     -   id: pyupgrade
 ```
 
+## As a command-line tool
+
+Call `pyupgrade` with the files you want to upgrade as arguments. If you pass a
+directory, it will be walked through and all Python files will be upgraded.
+
+```
+pyupgrade file1.py file2.py directory
+```
+
 ## Implemented features
 
 ### Set literals

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -1,6 +1,7 @@
 import argparse
 import ast
 import collections
+import os
 import re
 import string
 import sys
@@ -925,7 +926,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     ret = 0
     for filename in args.filenames:
-        ret |= _fix_file(filename, args)
+        if os.path.isdir(filename):
+            for root, dirs, files in os.walk(filename):
+                for child_filename in files:
+                    if not child_filename.endswith('.py'):
+                        continue
+                    ret |= _fix_file(os.path.join(root, child_filename), args)
+        else:
+            ret |= _fix_file(filename, args)
     return ret
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -215,3 +215,19 @@ def test_main_stdin_with_changes(capsys):
         assert main(('-',)) == 1
     out, err = capsys.readouterr()
     assert out == '{1, 2}\n'
+
+
+def test_main_recurse(tmpdir):
+    d = tmpdir.mkdir('dir')
+    f = d.join('t.py')
+    f.write('set((1, 2))\n')
+    assert main((str(d),)) == 1
+    assert f.read() == '{1, 2}\n'
+
+
+def test_main_recurse_only_py(tmpdir):
+    d = tmpdir.mkdir('dir')
+    f = d.join('t.notpy')
+    f.write('set((1, 2))\n')
+    assert not main((str(d),)) == 1
+    assert f.read() == 'set((1, 2))\n'


### PR DESCRIPTION
This commit makes it easier to use `pyupgrade` as a command line tool and not in the pre-commit hook.

Please feel free to adjust the language in the `README`, as English is not my first language.