### PR TITLE
don't rewrite list comp to generator expression in short-circuiting f…

### DIFF
--- a/pyupgrade/_plugins/generator_expressions_pep289.py
+++ b/pyupgrade/_plugins/generator_expressions_pep289.py
@@ -15,8 +15,6 @@ from pyupgrade._token_helpers import find_comprehension_opening_bracket
 
 
 ALLOWED_FUNCS = frozenset((
-    'all',
-    'any',
     'bytearray',
     'bytes',
     'frozenset',


### PR DESCRIPTION
…unctions

consider the side-effecting function `_upgrade`

```
if not all([_upgrade(x) for x in items]):
    raise ValidationError("one or more items failed to upgrade")
``` 

the functions `all` and `any` don't always consume their input fully and so will skip the side-effect for those items