### PR TITLE
fix six.with_metaclass and trailing commas

### DIFF
--- a/pyupgrade/_token_helpers.py
+++ b/pyupgrade/_token_helpers.py
@@ -410,7 +410,15 @@ def replace_call(
     ):
         start_rest += 1
 
-    rest = tokens_to_src(tokens[start_rest:end - 1])
+    # Remove trailing comma
+    end_rest = end - 1
+    while (
+            tokens[end_rest - 1].name == 'OP' and
+            tokens[end_rest - 1].src == ','
+    ):
+        end_rest -= 1
+
+    rest = tokens_to_src(tokens[start_rest:end_rest])
     src = tmpl.format(args=arg_strs, rest=rest)
     tokens[start:end] = [Token('CODE', src)]
 

--- a/tests/features/six_test.py
+++ b/tests/features/six_test.py
@@ -216,6 +216,13 @@ def test_fix_six_noop(s):
             id='elide object base in with_metaclass',
         ),
         pytest.param(
+            'class C(six.with_metaclass(M, B,)): pass',
+
+            'class C(B, metaclass=M): pass',
+
+            id='with_metaclass and trailing comma',
+        ),
+        pytest.param(
             '@six.add_metaclass(M)\n'
             'class C: pass\n',
 


### PR DESCRIPTION
xref https://github.com/asottile/pyupgrade/pull/364#issuecomment-845651933

> @MarcoGorelli btw, if you find the open wip PRs interesting feel free to take them over -- haven't had time to finish them up