### PR TITLE
rewrite cElementTree to ElementTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -451,6 +451,19 @@ Availability:
 ```
 
 
+### Rewrite `xml.etree.cElementTree` to `xml.etree.ElementTree`
+
+Availability:
+- `--py3-plus` is passed on the commandline.
+
+```diff
+-import xml.etree.cElementTree as ET
++import xml.etree.ElementTree as ET
+-from xml.etree.cElementTree import XML
++from xml.etree.ElementTree import XML
+```
+
+
 ### `typing.NamedTuple` / `typing.TypedDict` py36+ syntax
 
 Availability:

--- a/pyupgrade/_plugins/c_element_tree.py
+++ b/pyupgrade/_plugins/c_element_tree.py
@@ -1,0 +1,50 @@
+import ast
+from typing import Iterable
+from typing import List
+from typing import Tuple
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from pyupgrade._ast_helpers import ast_to_offset
+from pyupgrade._data import register
+from pyupgrade._data import State
+from pyupgrade._data import TokenFunc
+from pyupgrade._token_helpers import find_token
+
+
+def _replace_celementtree_with_elementtree(
+        i: int,
+        tokens: List[Token],
+) -> None:
+    j = find_token(tokens, i, 'cElementTree')
+    tokens[j] = tokens[j]._replace(src='ElementTree')
+
+
+@register(ast.ImportFrom)
+def visit_ImportFrom(
+        state: State,
+        node: ast.ImportFrom,
+        parent: ast.AST,
+) -> Iterable[Tuple[Offset, TokenFunc]]:
+    if (
+            state.settings.min_version >= (3,) and
+            node.module == 'xml.etree.cElementTree' and
+            node.level == 0
+    ):
+        yield ast_to_offset(node), _replace_celementtree_with_elementtree
+
+
+@register(ast.Import)
+def visit_Import(
+        state: State,
+        node: ast.Import,
+        parent: ast.AST,
+) -> Iterable[Tuple[Offset, TokenFunc]]:
+    if (
+        state.settings.min_version >= (3,) and
+        len(node.names) == 1 and
+        node.names[0].name == 'xml.etree.cElementTree' and
+        node.names[0].asname is not None
+    ):
+        yield ast_to_offset(node), _replace_celementtree_with_elementtree

--- a/tests/features/c_element_tree_test.py
+++ b/tests/features/c_element_tree_test.py
@@ -1,0 +1,57 @@
+import pytest
+
+from pyupgrade._data import Settings
+from pyupgrade._main import _fix_plugins
+
+
+@pytest.mark.parametrize(
+    ('s', 'version'),
+    (
+        pytest.param(
+            'import xml.etree.cElementTree as ET',
+            (2, 7),
+            id='not Python3+',
+        ),
+        pytest.param(
+            'import contextlib, xml.etree.ElementTree as ET\n',
+            (3,),
+            id='does not rewrite multiple imports',
+        ),
+        pytest.param(
+            'from .xml.etree.cElementTree import XML\n',
+            (3,),
+            id='leave relative imports alone',
+        ),
+        pytest.param(
+            'import xml.etree.cElementTree',
+            (3,),
+            id='import without alias',
+        ),
+    ),
+)
+def test_c_element_tree_noop(s, version):
+    assert _fix_plugins(s, settings=Settings(min_version=version)) == s
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        pytest.param(
+            'from xml.etree.cElementTree import XML\n',
+            'from xml.etree.ElementTree import XML\n',
+            id='relative import func',
+        ),
+        pytest.param(
+            'from xml.etree.cElementTree import XML, Element\n',
+            'from xml.etree.ElementTree import XML, Element\n',
+            id='import multiple objects',
+        ),
+        pytest.param(
+            'import xml.etree.cElementTree as ET',
+            'import xml.etree.ElementTree as ET',
+            id='import with alias',
+        ),
+    ),
+)
+def test_fix_c_element_tree(s, expected):
+    assert _fix_plugins(s, settings=Settings(min_version=(3,))) == expected


### PR DESCRIPTION
closes #311 

there's not currently a `--py33-plus` flag, should that be added or is `--py36-plus` OK?