### PR TITLE
Add defensive check for pep563

### DIFF
--- a/pyupgrade/_plugins/typing_pep563.py
+++ b/pyupgrade/_plugins/typing_pep563.py
@@ -129,7 +129,13 @@ def _replace_string_literal(
                 if isinstance(value, ast.AST):
                     nodes.append(value)
                 elif isinstance(value, list):
-                    nodes.extend(value)
+                    for value_ in value:
+                        if isinstance(value_, ast.AST):
+                            nodes.append(value_)
+                        else:
+                            raise AssertionError(
+                                f'expected AST: {ast.dump(value_)}',
+                            )
 
 
 def _process_args(


### PR DESCRIPTION
I haven't been able to find a test case which would hit the `else` block here, but if there was one, then `nodes` would contain an object which isn't `ast.AST` and so wouldn't have a `_fields` attribute. Is there a test which could be added, or is a defensive check like this OK?