### PR TITLE
f"wat".encode("utf-8") can also be rewritten to remove the encoding

### DIFF
--- a/pyupgrade/_plugins/default_encoding.py
+++ b/pyupgrade/_plugins/default_encoding.py
@@ -31,7 +31,7 @@ def visit_Call(
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.func, ast.Attribute) and
-            isinstance(node.func.value, ast.Str) and
+            isinstance(node.func.value, (ast.Str, ast.JoinedStr)) and
             node.func.attr == 'encode' and
             not has_starargs(node) and
             len(node.args) == 1 and

--- a/tests/features/default_encoding_test.py
+++ b/tests/features/default_encoding_test.py
@@ -8,6 +8,10 @@ from pyupgrade._main import _fix_plugins
     ('s', 'expected'),
     (
         ('"asd".encode("utf-8")', '"asd".encode()'),
+        ('f"asd".encode("utf-8")', 'f"asd".encode()'),
+        ('f"{3}asd".encode("utf-8")', 'f"{3}asd".encode()'),
+        ('fr"asd".encode("utf-8")', 'fr"asd".encode()'),
+        ('r"asd".encode("utf-8")', 'r"asd".encode()'),
         ('"asd".encode("utf8")', '"asd".encode()'),
         ('"asd".encode("UTF-8")', '"asd".encode()'),
         pytest.param(


### PR DESCRIPTION
closes #483 