### PR TITLE
support directories in main targets

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -895,7 +895,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
         return contents_text != contents_text_orig
 
 
-def _walkfiles(folder: str, suffix: str = '') -> Iterator:
+def _walkfiles(folder: str, suffix: str = '') -> Iterator[str]:
     """Iterator over files in folder, recursively."""
     return (
         os.path.join(basename, filename)

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -1,11 +1,13 @@
 import argparse
 import ast
 import collections
+import os
 import re
 import string
 import sys
 import tokenize
 from typing import Dict
+from typing import Iterator
 from typing import List
 from typing import Match
 from typing import Optional
@@ -893,9 +895,19 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
         return contents_text != contents_text_orig
 
 
+def _walkfiles(folder: str, suffix: str = '') -> Iterator:
+    """Iterator over files in folder, recursively."""
+    return (
+        os.path.join(basename, filename)
+        for basename, dirnames, filenames in os.walk(folder)
+        for filename in filenames
+        if filename.endswith(suffix)
+    )
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     parser = argparse.ArgumentParser()
-    parser.add_argument('filenames', nargs='*')
+    parser.add_argument('targets', nargs='*')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
@@ -931,8 +943,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     ret = 0
-    for filename in args.filenames:
-        ret |= _fix_file(filename, args)
+    for target in args.targets:
+        if os.path.isdir(target):
+            for filename in _walkfiles(target, '.py'):
+                ret |= _fix_file(filename, args)
+        else:
+            ret |= _fix_file(target, args)
     return ret
 
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -44,6 +44,29 @@ def test_main_changes_a_file(tmpdir, capsys):
     assert f.read() == 'x = {1, 2, 3}\n'
 
 
+def test_main_walks_through_subdirs(tmpdir, capsys):
+    sub = tmpdir.mkdir('sub')
+    sub_sub = sub.mkdir('sub')
+
+    a = sub.join('a.py')
+    a.write('x = set((1, 2, 3))\n')
+    b = sub.join('b.py')
+    b.write('x = set((1, 2, 3))\n')
+    c = sub_sub.join('c.py')
+    c.write('x = set((1, 2, 3))\n')
+
+    assert main((sub.strpath,)) == 1
+    out, err = capsys.readouterr()
+    assert err == (
+        f'Rewriting {a.strpath}\n'
+        f'Rewriting {b.strpath}\n'
+        f'Rewriting {c.strpath}\n'
+    )
+    assert a.read() == 'x = {1, 2, 3}\n'
+    assert b.read() == 'x = {1, 2, 3}\n'
+    assert c.read() == 'x = {1, 2, 3}\n'
+
+
 def test_main_keeps_line_endings(tmpdir, capsys):
     f = tmpdir.join('f.py')
     f.write_binary(b'x = set((1, 2, 3))\r\n')


### PR DESCRIPTION
Patch to add support for recursively upgrading `.py` files in folders too, written on the back of mozilla/addons-server#17571