### PR TITLE
Add extra test for pep584 with comma inside comprehension

### DIFF
--- a/tests/features/pep584_test.py
+++ b/tests/features/pep584_test.py
@@ -104,6 +104,19 @@ def test_fix_pep584_noop(s, version):
 
             id='Dict comprehension within merge of dicts',
         ),
+        pytest.param(
+            'x = {\n'
+            '    **{a: b for a, b in zip(range(3), range(3))},\n'
+            '    **b,\n'
+            '}\n',
+
+            'x = (\n'
+            '    {a: b for a, b in zip(range(3), range(3))} |\n'
+            '    b\n'
+            ')\n',
+
+            id='Dict with comma inside it',
+        ),
     ),
 )
 def test_fix_pep584(s, expected):


### PR DESCRIPTION
The test I'd added in https://github.com/asottile/pyupgrade/pull/505 didn't, at the time, fail on master - sorry about that, I should've done "red green refactor"

To make sure the bug doesn't appear again, I've added a test which would've failed in that version of pyupgrade:
```console
(venv39) marcogorelli@OVMG025 pyupgrade-dev % git checkout v2.23.0 -- pyupgrade       
(venv39) marcogorelli@OVMG025 pyupgrade-dev % pytest tests/features/pep584_test.py -qq
..........F                                                                                                                                [100%]
==================================================================== FAILURES ====================================================================
___________________________________________________ test_fix_pep584[Dict with comma inside it] ___________________________________________________

s = 'x = {\n    **{a: b for a, b in zip(range(3), range(3))},\n    **b,\n}\n'
expected = 'x = (\n    {a: b for a, b in zip(range(3), range(3))} |\n    b\n)\n'

    @pytest.mark.parametrize(
        ('s', 'expected'),
        (
            pytest.param(
                'x = {**a, **b}\n',
    
                'x = a | b\n',
    
                id='Simple dict rewrite',
            ),
            pytest.param(
                'x = {**{**a, **b}, **c}\n',
    
                'x = a | b | c\n',
    
                id='Nested merge of dicts',
            ),
            pytest.param(
                'x = {**a, **b,}\n',
    
                'x = a | b\n',
    
                id='Trailing comma',
            ),
            pytest.param(
                'x = {\n'
                '    **a,  # foo\n'
                '    **b  # bar\n'
                '}\n',
    
                'x = (\n'
                '    a |  # foo\n'
                '    b  # bar\n'
                ')\n',
    
                id='Multiple lines with comment',
            ),
            pytest.param(
                'x = {\n'
                '    **a,\n'
                '    **b\n'
                '}\n',
    
                'x = (\n'
                '    a |\n'
                '    b\n'
                ')\n',
    
                id='Multiple lines',
            ),
            pytest.param(
                'x = {\n'
                '    **a,\n'
                '    **b,\n'
                '}\n',
    
                'x = (\n'
                '    a |\n'
                '    b\n'
                ')\n',
    
                id='Multiple lines, trailing comma',
            ),
            pytest.param(
                'x = {\n'
                '    **{a: a for a  in range(3)},\n'
                '    **b,\n'
                '}\n',
    
                'x = (\n'
                '    {a: a for a  in range(3)} |\n'
                '    b\n'
                ')\n',
    
                id='Dict comprehension within merge of dicts',
            ),
            pytest.param(
                'x = {\n'
                '    **{a: b for a, b in zip(range(3), range(3))},\n'
                '    **b,\n'
                '}\n',
    
                'x = (\n'
                '    {a: b for a, b in zip(range(3), range(3))} |\n'
                '    b\n'
                ')\n',
    
                id='Dict with comma inside it',
            ),
        ),
    )
    def test_fix_pep584(s, expected):
>       assert _fix_plugins(s, settings=Settings(min_version=(3, 9))) == expected
E       AssertionError: assert 'x = (\n    {...,\n    b\n)\n' == 'x = (\n    {...|\n    b\n)\n'
E           x = (
E         -     {a: b for a, b in zip(range(3), range(3))} |
E         ?                ^                              ^^
E         +     {a: b for a | b in zip(range(3), range(3))},
E         ?                ^^                              ^
E               b
E           )

tests/features/pep584_test.py:123: AssertionError
============================================================ short test summary info =============================================================
FAILED tests/features/pep584_test.py::test_fix_pep584[Dict with comma inside it] - AssertionError: assert 'x = (\n    {...,\n    b\n)\n' == 'x ...
(venv39) marcogorelli@OVMG025 pyupgrade-dev % git checkout HEAD -- pyupgrade          
(venv39) marcogorelli@OVMG025 pyupgrade-dev % pytest tests/features/pep584_test.py -qq
...........                                 
```
