### PR TITLE
ENH: expand versioned_branches feature to Python 3 minor version comparison (<, >, <=, >= with else)

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,20 +294,57 @@ def f():
         yield (a, b)
 ```
 
-### `if PY2` blocks
+### Python2 and old Python3.x blocks
 
 Availability:
 - `--py3-plus` is passed on the commandline.
 
 ```python
 # input
-if six.PY2:      # also understands `six.PY3` and `not` and `sys.version_info`
+import sys
+if sys.version_info < (3,):  # also understands `six.PY2` (and `not`), `six.PY3` (and `not`)
     print('py2')
 else:
     print('py3')
 # output
+import sys
 print('py3')
 ```
+
+Availability:
+- `--py36-plus` will remove Python <= 3.5 only blocks
+- `--py37-plus` will remove Python <= 3.6 only blocks
+- so on and so forth
+
+```python
+# using --py36-plus for this example
+# input
+import sys
+if sys.version_info < (3, 6):
+    print('py3.5')
+else:
+    print('py3.6+')
+
+if sys.version_info <= (3, 5):
+    print('py3.5')
+else:
+    print('py3.6+')
+
+if sys.version_info >= (3, 6):
+    print('py3.6+')
+else:
+    print('py3.5')
+
+# output
+import sys
+print('py3.6+')
+
+print('py3.6+')
+
+print('py3.6+')
+```
+
+Note that `if` blocks without an `else` will not be rewriten as it could introduce a syntax error.
 
 ### remove `six` compatibility code
 


### PR DESCRIPTION
Fix #488
It should cover Python 3.x branches (where x is >=0) using operators `<`, `<=`, `>`, `>=`, and assuming
that an `else` statement exists.

A couple remarks:
- this is my very first contribution to anything that uses `ast`, so I'm kind of astonished that my own tests are passing, but I'll gladly take any suggestions on how to make this better
- I ended up kinda "hacking" existing functions (namely `_fix_py3_block`, `_fix_py3_block_else` and `_fix_py2_block`) in the sense that I'm using them without modifications in a different fashion compared to their original intended usage. I suppose they ought to be renamed to better reflect what they actually do here (fix and if/else block and keep the top or lower half ?), but I leave this as a question to the maintainer
- I didn't cover the `==` operator. I can do it if you feel it's necessary, but I thought I'd ask for feedback first.

So... what do you think ? anything obvious that I'm not covering in the tests yet ?