### PR TITLE
BUG: fix broken tests for versioned_branches feature

### DIFF
--- a/tests/features/versioned_branches_test.py
+++ b/tests/features/versioned_branches_test.py
@@ -545,6 +545,15 @@ def test_fix_py3_only_code(s, expected):
             '3+6\n',
             id='from sys import version_info, <= (3, 5)',
         ),
+        pytest.param(
+            'import sys\n'
+            'if sys.version_info >= (3, 6):\n'
+            '    pass',
+
+            'import sys\n'
+            'pass',
+            id='sys.version_info >= (3, 6), noelse',
+        ),
     ),
 )
 def test_fix_py3x_only_code(s, expected):
@@ -555,15 +564,6 @@ def test_fix_py3x_only_code(s, expected):
 @pytest.mark.parametrize(
     's',
     (
-        # we timidly skip `if` without `else` as it could cause a SyntaxError
-        'import sys'
-        'if sys.version_info >= (3, 6):\n'
-        '    pass',
-        # here's the case where it causes a SyntaxError
-        'import sys'
-        'if True'
-        '    if sys.version_info >= (3, 6):\n'
-        '        pass\n',
         # both branches are still relevant in the following cases
         'import sys\n'
         'if sys.version_info > (3, 7):\n'


### PR DESCRIPTION
Followup to #530, thanks to [a comment from @graingert](https://github.com/asottile/pyupgrade/commit/31546d2cdf4a7647df46b0e9c4b771efe123ea3b#r56396117)

Actually the bug now fails, revealing a bug in #530 ? I'll try to fix this promptly