### PR TITLE
Remove `from __future__ import annotations` on --py310-plus

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -406,7 +406,7 @@ def _build_import_removals() -> Dict[Version, Dict[str, Tuple[str, ...]]]:
         ((3, 7), ('generator_stop',)),
         ((3, 8), ()),
         ((3, 9), ()),
-        ((3, 10), ()),
+        ((3, 10), ('annotations',)),
         ((3, 11), ()),
     )
 

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -147,7 +147,7 @@ def test_py36_plus_fstrings(tmpdir):
     assert f.read() == 'f"{hello} {world}"'
 
 
-def test_py37_plus_removes_annotations(tmpdir):
+def test_py37_plus_removes_generator_stop(tmpdir):
     f = tmpdir.join('f.py')
     f.write('from __future__ import generator_stop\nx = 1\n')
     assert main((f.strpath,)) == 0
@@ -215,3 +215,14 @@ def test_main_stdin_with_changes(capsys):
         assert main(('-',)) == 1
     out, err = capsys.readouterr()
     assert out == '{1, 2}\n'
+
+
+def test_py310_plus_removes_generator_stop(tmpdir):
+    f = tmpdir.join('f.py')
+    f.write('from __future__ import annotations\nx = 1\n')
+    assert main((f.strpath,)) == 0
+    assert main((f.strpath, '--py37-plus')) == 0
+    assert main((f.strpath, '--py38-plus')) == 0
+    assert main((f.strpath, '--py39-plus')) == 0
+    assert main((f.strpath, '--py310-plus')) == 1
+    assert f.read() == 'x = 1\n'


### PR DESCRIPTION
Also fixed the test name for generator_stop, not sure if that was
intended or I'm misreading it x)

Closes #551.