### PR TITLE
fix relative import of mock module

### DIFF
--- a/pyupgrade/_plugins/mock.py
+++ b/pyupgrade/_plugins/mock.py
@@ -56,7 +56,7 @@ def _fix_relative_import_mock(i: int, tokens: List[Token], name: ast.Name, n: in
 
 
 def _fix_import_from_mock(i: int, tokens: List[Token], names: List[ast.Name]) -> None:
-    
+
     name = next((name for name in names if name.name == 'mock'), None)
     if name:
         _fix_relative_import_mock(i, tokens, name, len(names))

--- a/pyupgrade/_plugins/mock.py
+++ b/pyupgrade/_plugins/mock.py
@@ -1,7 +1,8 @@
 import ast
 import functools
-from typing import Iterable, Optional
+from typing import Iterable
 from typing import List
+from typing import Optional
 from typing import Tuple
 
 from tokenize_rt import Offset
@@ -11,7 +12,8 @@ from pyupgrade._ast_helpers import ast_to_offset
 from pyupgrade._data import register
 from pyupgrade._data import State
 from pyupgrade._data import TokenFunc
-from pyupgrade._token_helpers import find_token, find_end
+from pyupgrade._token_helpers import find_end
+from pyupgrade._token_helpers import find_token
 
 MOCK_MODULES = frozenset(('mock', 'mock.mock'))
 
@@ -21,7 +23,7 @@ def _add_import(i: int, tokens: List[Token], module: str, name: str, alias: Opti
     if alias:
         asname = f' as {alias}'
     src = f'from {module} import {name}{asname}\n'
-    tokens.insert(i, Token('CODE', src))    
+    tokens.insert(i, Token('CODE', src))
 
 
 def _remove_import(i: int, tokens: List[Token]) -> None:
@@ -46,13 +48,12 @@ def _fix_relative_import_mock(i: int, tokens: List[Token], names: List[ast.Name]
         src = 'unittest'
         tokens[j:j + 1] = [tokens[j]._replace(name='NAME', src=src)]
     else:
-        name: ast.Name = next((name for name in names if name.name == 'mock'))
+        name: ast.Name = next(name for name in names if name.name == 'mock')
         src = 'unittest.mock'
         tokens[j:j + 1] = [tokens[j]._replace(name='NAME', src=src)]
-        idx = find_token(tokens, j+1, 'mock')
+        idx = find_token(tokens, j + 1, 'mock')
         _remove_import(idx, tokens)
         _add_import(i, tokens, 'unittest', name.name, name.asname)
-
 
 
 def _fix_import_from_mock(i: int, tokens: List[Token], names: List[ast.Name]) -> None:

--- a/pyupgrade/_plugins/mock.py
+++ b/pyupgrade/_plugins/mock.py
@@ -22,7 +22,7 @@ def _add_import(
         tokens: List[Token],
         module: str,
         name: str,
-        alias: Optional[str]
+        alias: Optional[str],
 ) -> None:
     asname = ''
     if alias:
@@ -50,7 +50,7 @@ def _fix_relative_import_mock(
         i: int,
         tokens: List[Token],
         name: ast.alias,
-        n: int
+        n: int,
 ) -> None:
     j = find_token(tokens, i, 'mock')
 
@@ -68,7 +68,7 @@ def _fix_relative_import_mock(
 def _fix_import_from_mock(
         i: int,
         tokens: List[Token],
-        names: List[ast.alias]
+        names: List[ast.alias],
 ) -> None:
     name = next((name for name in names if name.name == 'mock'), None)
     if name:

--- a/pyupgrade/_plugins/mock.py
+++ b/pyupgrade/_plugins/mock.py
@@ -12,13 +12,18 @@ from pyupgrade._ast_helpers import ast_to_offset
 from pyupgrade._data import register
 from pyupgrade._data import State
 from pyupgrade._data import TokenFunc
-from pyupgrade._token_helpers import find_end
 from pyupgrade._token_helpers import find_token
 
 MOCK_MODULES = frozenset(('mock', 'mock.mock'))
 
 
-def _add_import(i: int, tokens: List[Token], module: str, name: str, alias: Optional[str]) -> None:
+def _add_import(
+        i: int,
+        tokens: List[Token],
+        module: str,
+        name: str,
+        alias: Optional[str]
+) -> None:
     asname = ''
     if alias:
         asname = f' as {alias}'
@@ -41,7 +46,12 @@ def _remove_import(i: int, tokens: List[Token]) -> None:
     del tokens[i:j]
 
 
-def _fix_relative_import_mock(i: int, tokens: List[Token], name: ast.Name, n: int) -> None:
+def _fix_relative_import_mock(
+        i: int,
+        tokens: List[Token],
+        name: ast.alias,
+        n: int
+) -> None:
     j = find_token(tokens, i, 'mock')
 
     if n == 1:
@@ -55,8 +65,11 @@ def _fix_relative_import_mock(i: int, tokens: List[Token], name: ast.Name, n: in
         _add_import(i, tokens, 'unittest', name.name, name.asname)
 
 
-def _fix_import_from_mock(i: int, tokens: List[Token], names: List[ast.Name]) -> None:
-
+def _fix_import_from_mock(
+        i: int,
+        tokens: List[Token],
+        names: List[ast.alias]
+) -> None:
     name = next((name for name in names if name.name == 'mock'), None)
     if name:
         _fix_relative_import_mock(i, tokens, name, len(names))

--- a/pyupgrade/_plugins/mock.py
+++ b/pyupgrade/_plugins/mock.py
@@ -41,14 +41,13 @@ def _remove_import(i: int, tokens: List[Token]) -> None:
     del tokens[i:j]
 
 
-def _fix_relative_import_mock(i: int, tokens: List[Token], names: List[ast.Name]) -> None:
+def _fix_relative_import_mock(i: int, tokens: List[Token], name: ast.Name, n: int) -> None:
     j = find_token(tokens, i, 'mock')
 
-    if len(names) == 1:
+    if n == 1:
         src = 'unittest'
         tokens[j:j + 1] = [tokens[j]._replace(name='NAME', src=src)]
     else:
-        name: ast.Name = next(name for name in names if name.name == 'mock')
         src = 'unittest.mock'
         tokens[j:j + 1] = [tokens[j]._replace(name='NAME', src=src)]
         idx = find_token(tokens, j + 1, 'mock')
@@ -57,8 +56,10 @@ def _fix_relative_import_mock(i: int, tokens: List[Token], names: List[ast.Name]
 
 
 def _fix_import_from_mock(i: int, tokens: List[Token], names: List[ast.Name]) -> None:
-    if any(n.name == 'mock' for n in names):
-        _fix_relative_import_mock(i, tokens, names)
+    
+    name = next((name for name in names if name.name == 'mock'), None)
+    if name:
+        _fix_relative_import_mock(i, tokens, name, len(names))
     else:
         j = find_token(tokens, i, 'mock')
         if (

--- a/tests/features/mock_test.py
+++ b/tests/features/mock_test.py
@@ -92,14 +92,10 @@ def test_mock_noop_keep_mock():
             id='relative import func and mock',
         ),
         pytest.param(
-            'from mock import (\n'
-            '  mock as mock2, patch\n'
-            ')\n',
+            'from mock import (patch, mock as mock2)',
             'from unittest import mock as mock2\n'
-            'from unittest.mock import (\n'
-            '   patch\n'
-            ')\n',
-            id='relative import func and mock',
+            'from unittest.mock import (patch)',
+            id='relative import func and mock with as',
         ),
 
         pytest.param(

--- a/tests/features/mock_test.py
+++ b/tests/features/mock_test.py
@@ -78,19 +78,19 @@ def test_mock_noop_keep_mock():
             'from mock import mock\n',
             'from unittest import mock\n',
             id='relative import mock',
-        ),        
+        ),
         pytest.param(
             'from mock import mock, patch\n',
             'from unittest import mock\n'
             'from unittest.mock import  patch\n',
             id='relative import mock and func',
-        ),        
+        ),
         pytest.param(
             'from mock import patch, mock\n',
             'from unittest import mock\n'
             'from unittest.mock import patch\n',
             id='relative import func and mock',
-        ),        
+        ),
         pytest.param(
             'from mock import (\n'
             '  mock as mock2, patch\n'
@@ -100,7 +100,7 @@ def test_mock_noop_keep_mock():
             '   patch\n'
             ')\n',
             id='relative import func and mock',
-        ),               
+        ),
 
         pytest.param(
             'from mock import patch\n'

--- a/tests/features/mock_test.py
+++ b/tests/features/mock_test.py
@@ -75,6 +75,34 @@ def test_mock_noop_keep_mock():
         ),
 
         pytest.param(
+            'from mock import mock\n',
+            'from unittest import mock\n',
+            id='relative import mock',
+        ),        
+        pytest.param(
+            'from mock import mock, patch\n',
+            'from unittest import mock\n'
+            'from unittest.mock import  patch\n',
+            id='relative import mock and func',
+        ),        
+        pytest.param(
+            'from mock import patch, mock\n',
+            'from unittest import mock\n'
+            'from unittest.mock import patch\n',
+            id='relative import func and mock',
+        ),        
+        pytest.param(
+            'from mock import (\n'
+            '  mock as mock2, patch\n'
+            ')\n',
+            'from unittest import mock as mock2\n'
+            'from unittest.mock import (\n'
+            '   patch\n'
+            ')\n',
+            id='relative import func and mock',
+        ),               
+
+        pytest.param(
             'from mock import patch\n'
             '\n'
             'patch.object(Foo, "func")\n',


### PR DESCRIPTION
Fixes https://github.com/asottile/pyupgrade/issues/549

## Description
`from mock import mock` is syntactically valid.
Without this patch, this transforms to `from unittest.mock import mock` (syntactically invalid)
With this patch, this line becomes `from unittest import mock`

## Details
This patch looks for the identifier `mock` in the `names` part of the `ImportFrom` AST node. Then, it handles this case in one of two ways:
 1. `len(names) == 1`.
   a. rewrite the module: `mock` -> `unittest`
 2. `len(names) > 1`. 
   a. rewrite the module: `mock` -> `unittest.mock`
   b. remove the identifier `mock` from the list of `names`.
   c. add import on a new line: `from unittest import mock`