### PR TITLE
Improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,7 +748,7 @@ Availability:
 
 Availability:
 - File imports `from __future__ import annotations`
-    - unless `--keep-runtime-typing` is passed on the commandline.
+    - unless `--keep-runtime-typing` is passed on the commandline (to avoid breaking Pydantic and similar tools).
 - or `--py39-plus` is passed on the commandline.
 
 ```diff
@@ -775,7 +775,7 @@ Availability:
 
 Availability:
 - File imports `from __future__ import annotations`
-    - unless `--keep-runtime-typing` is passed on the commandline.
+    - unless `--keep-runtime-typing` is passed on the commandline (to avoid breaking Pydantic and similar tools).
 - or `--py310-plus` is passed on the commandline.
 
 ```diff

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Availability:
 
 Availability:
 - File imports `from __future__ import unicode_literals`
-- `--py3-plus` is passed on the commandline.
+- or `--py3-plus` is passed on the commandline.
 
 ```diff
 -u'foo'
@@ -326,7 +326,7 @@ Availability:
 
 Availability:
 - `--py3-plus` is passed on the commandline.
-- [Unless `--keep-mock` is passed on the commandline](https://github.com/asottile/pyupgrade/issues/314).
+- [unless `--keep-mock` is passed on the commandline](https://github.com/asottile/pyupgrade/issues/314).
 
 ```diff
 -from mock import patch
@@ -748,8 +748,8 @@ Availability:
 
 Availability:
 - File imports `from __future__ import annotations`
-    - Unless `--keep-runtime-typing` is passed on the commandline.
-- `--py39-plus` is passed on the commandline.
+    - unless `--keep-runtime-typing` is passed on the commandline.
+- or `--py39-plus` is passed on the commandline.
 
 ```diff
 -def f(x: List[str]) -> None:
@@ -775,8 +775,8 @@ Availability:
 
 Availability:
 - File imports `from __future__ import annotations`
-    - Unless `--keep-runtime-typing` is passed on the commandline.
-- `--py310-plus` is passed on the commandline.
+    - unless `--keep-runtime-typing` is passed on the commandline.
+- or `--py310-plus` is passed on the commandline.
 
 ```diff
 -def f() -> Optional[str]:
@@ -795,7 +795,7 @@ Availability:
 
 Availability:
 - File imports `from __future__ import annotations`
-- `--py311-plus` is passed on the commandline.
+- or `--py311-plus` is passed on the commandline.
 
 ```diff
 -def f(x: 'queue.Queue[int]') -> C:


### PR DESCRIPTION
I was really confused while trying to understand the README regarding #415. This PR would have cleared up my confusion.

1. I couldn't figure out whether the default boolean operation corresponding to a list is `and` or `or`. Turns out it's `or`.
2. There's no explanation of the purpose of `--keep-runtime-typing`.

Maybe I'm just exceptionally slow, but here was my train of thought:

I'm working on a project involving Pydantic which has been upgraded to 3.9. I know I need to disable PEP 604. But I don't want to disable PEP 585. The file imports `annotations` from `__future__`, so even if I use `--py39-plus` I'll lose PEP 585 (WRONG since 1. is not `and`!). Therefore, there is no flag which does what I want (WRONG because 2.).