### PR TITLE
drop python3.6 support

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -27,7 +27,7 @@ repos:
     rev: v2.6.0
     hooks:
     -   id: reorder-python-imports
-        args: [--py3-plus]
+        args: [--py37-plus, --add-import, 'from __future__ import annotations']
 -   repo: https://github.com/asottile/add-trailing-comma
     rev: v2.2.1
     hooks:
@@ -37,7 +37,7 @@ repos:
     rev: v2.31.0
     hooks:
     -   id: pyupgrade
-        args: [--py36-plus]
+        args: [--py37-plus]
 -   repo: https://github.com/pre-commit/mirrors-mypy
     rev: v0.931
     hooks:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.1.0
+      ref: refs/tags/v2.4.0
 
 jobs:
 - template: job--python-tox.yml@asottile
@@ -19,5 +19,5 @@ jobs:
     os: windows
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [pypy3, py36, py37, py38, py39]
+    toxenvs: [py37, py38, py39]
     os: linux

--- a/pyupgrade/__main__.py
+++ b/pyupgrade/__main__.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 from pyupgrade._main import main
 
 if __name__ == '__main__':

--- a/pyupgrade/_ast_helpers.py
+++ b/pyupgrade/_ast_helpers.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import ast
 import warnings
 from typing import Container
-from typing import Dict
-from typing import Set
-from typing import Union
 
 from tokenize_rt import Offset
 
@@ -15,13 +14,13 @@ def ast_parse(contents_text: str) -> ast.Module:
         return ast.parse(contents_text.encode())
 
 
-def ast_to_offset(node: Union[ast.expr, ast.stmt]) -> Offset:
+def ast_to_offset(node: ast.expr | ast.stmt) -> Offset:
     return Offset(node.lineno, node.col_offset)
 
 
 def is_name_attr(
         node: ast.AST,
-        imports: Dict[str, Set[str]],
+        imports: dict[str, set[str]],
         mod: str,
         names: Container[str],
 ) -> bool:

--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -1,14 +1,13 @@
+from __future__ import annotations
+
 import ast
 import collections
 import pkgutil
 from typing import Callable
-from typing import Dict
 from typing import Iterable
 from typing import List
 from typing import NamedTuple
-from typing import Set
 from typing import Tuple
-from typing import Type
 from typing import TYPE_CHECKING
 from typing import TypeVar
 
@@ -34,7 +33,7 @@ class Settings(NamedTuple):
 
 class State(NamedTuple):
     settings: Settings
-    from_imports: Dict[str, Set[str]]
+    from_imports: dict[str, set[str]]
     in_annotation: bool = False
 
 
@@ -59,7 +58,7 @@ RECORD_FROM_IMPORTS = frozenset((
 FUNCS = collections.defaultdict(list)
 
 
-def register(tp: Type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
+def register(tp: type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
     def register_decorator(func: ASTFunc[AST_T]) -> ASTFunc[AST_T]:
         FUNCS[tp].append(func)
         return func
@@ -67,20 +66,20 @@ def register(tp: Type[AST_T]) -> Callable[[ASTFunc[AST_T]], ASTFunc[AST_T]]:
 
 
 class ASTCallbackMapping(Protocol):
-    def __getitem__(self, tp: Type[AST_T]) -> List[ASTFunc[AST_T]]: ...
+    def __getitem__(self, tp: type[AST_T]) -> list[ASTFunc[AST_T]]: ...
 
 
 def visit(
         funcs: ASTCallbackMapping,
         tree: ast.Module,
         settings: Settings,
-) -> Dict[Offset, List[TokenFunc]]:
+) -> dict[Offset, list[TokenFunc]]:
     initial_state = State(
         settings=settings,
         from_imports=collections.defaultdict(set),
     )
 
-    nodes: List[Tuple[State, ast.AST, ast.AST]] = [(initial_state, tree, tree)]
+    nodes: list[tuple[State, ast.AST, ast.AST]] = [(initial_state, tree, tree)]
 
     ret = collections.defaultdict(list)
     while nodes:

--- a/pyupgrade/_plugins/abspath_file.py
+++ b/pyupgrade/_plugins/abspath_file.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -14,7 +14,7 @@ from pyupgrade._token_helpers import find_closing_bracket
 from pyupgrade._token_helpers import find_open_paren
 
 
-def _remove_abspath(i: int, tokens: List[Token]) -> None:
+def _remove_abspath(i: int, tokens: list[Token]) -> None:
     paren_start = find_open_paren(tokens, i + 1)
     paren_end = find_closing_bracket(tokens, paren_start)
     while i <= paren_start:
@@ -28,7 +28,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3, 9) and
             (

--- a/pyupgrade/_plugins/c_element_tree.py
+++ b/pyupgrade/_plugins/c_element_tree.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -15,7 +15,7 @@ from pyupgrade._token_helpers import find_token
 
 def _replace_celementtree_with_elementtree(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
 ) -> None:
     j = find_token(tokens, i, 'cElementTree')
     tokens[j] = tokens[j]._replace(src='ElementTree')
@@ -26,7 +26,7 @@ def visit_ImportFrom(
         state: State,
         node: ast.ImportFrom,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             node.module == 'xml.etree.cElementTree' and
@@ -40,7 +40,7 @@ def visit_Import(
         state: State,
         node: ast.Import,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
         state.settings.min_version >= (3,) and
         len(node.names) == 1 and

--- a/pyupgrade/_plugins/default_encoding.py
+++ b/pyupgrade/_plugins/default_encoding.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -16,7 +16,7 @@ from pyupgrade._token_helpers import find_closing_bracket
 from pyupgrade._token_helpers import find_open_paren
 
 
-def _fix_default_encoding(i: int, tokens: List[Token]) -> None:
+def _fix_default_encoding(i: int, tokens: list[Token]) -> None:
     i = find_open_paren(tokens, i + 1)
     j = find_closing_bracket(tokens, i)
     del tokens[i + 1:j]
@@ -27,7 +27,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.func, ast.Attribute) and

--- a/pyupgrade/_plugins/dict_literals.py
+++ b/pyupgrade/_plugins/dict_literals.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Tuple
-from typing import Union
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -20,8 +19,8 @@ from pyupgrade._token_helpers import victims
 
 def _fix_dict_comp(
         i: int,
-        tokens: List[Token],
-        arg: Union[ast.ListComp, ast.GeneratorExp],
+        tokens: list[Token],
+        arg: ast.ListComp | ast.GeneratorExp,
 ) -> None:
     if not immediately_paren('dict', tokens, i):
         return
@@ -52,7 +51,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             isinstance(node.func, ast.Name) and
             node.func.id == 'dict' and

--- a/pyupgrade/_plugins/format_locals.py
+++ b/pyupgrade/_plugins/format_locals.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import rfind_string_parts
@@ -16,7 +16,7 @@ from pyupgrade._token_helpers import find_open_paren
 from pyupgrade._token_helpers import find_token
 
 
-def _fix(i: int, tokens: List[Token]) -> None:
+def _fix(i: int, tokens: list[Token]) -> None:
     dot_pos = find_token(tokens, i, '.')
     open_pos = find_open_paren(tokens, dot_pos)
     close_pos = find_closing_bracket(tokens, open_pos)
@@ -31,7 +31,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3, 6) and
             isinstance(node.func, ast.Attribute) and

--- a/pyupgrade/_plugins/generator_expressions_pep289.py
+++ b/pyupgrade/_plugins/generator_expressions_pep289.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import Offset
@@ -30,7 +30,7 @@ ALLOWED_FUNCS = frozenset((
 ))
 
 
-def _delete_list_comp_brackets(i: int, tokens: List[Token]) -> None:
+def _delete_list_comp_brackets(i: int, tokens: list[Token]) -> None:
     start = find_comprehension_opening_bracket(i, tokens)
     end = find_closing_bracket(tokens, start)
     tokens[end] = Token('PLACEHOLDER', '')
@@ -47,7 +47,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             isinstance(node.func, ast.Name) and
             node.func.id in ALLOWED_FUNCS and

--- a/pyupgrade/_plugins/identity_equality.py
+++ b/pyupgrade/_plugins/identity_equality.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Tuple
-from typing import Union
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -18,9 +17,9 @@ LITERAL_TYPES = (ast.Str, ast.Num, ast.Bytes)
 
 def _fix_is_literal(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
-        op: Union[ast.Is, ast.IsNot],
+        op: ast.Is | ast.IsNot,
 ) -> None:
     while tokens[i].src != 'is':
         i -= 1
@@ -41,7 +40,7 @@ def visit_Compare(
         state: State,
         node: ast.Compare,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     left = node.left
     for op, right in zip(node.ops, node.comparators):
         if (

--- a/pyupgrade/_plugins/io_open.py
+++ b/pyupgrade/_plugins/io_open.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -13,7 +13,7 @@ from pyupgrade._data import TokenFunc
 from pyupgrade._token_helpers import find_open_paren
 
 
-def _replace_io_open(i: int, tokens: List[Token]) -> None:
+def _replace_io_open(i: int, tokens: list[Token]) -> None:
     j = find_open_paren(tokens, i)
     tokens[i:j] = [tokens[i]._replace(name='NAME', src='open')]
 
@@ -23,7 +23,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.func, ast.Attribute) and

--- a/pyupgrade/_plugins/legacy.py
+++ b/pyupgrade/_plugins/legacy.py
@@ -1,16 +1,12 @@
+from __future__ import annotations
+
 import ast
 import collections
 import contextlib
 import functools
 from typing import Any
-from typing import Dict
 from typing import Generator
 from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
-from typing import Type
-from typing import Union
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -28,7 +24,7 @@ from pyupgrade._token_helpers import find_token
 FUNC_TYPES = (ast.Lambda, ast.FunctionDef, ast.AsyncFunctionDef)
 
 
-def _fix_yield(i: int, tokens: List[Token]) -> None:
+def _fix_yield(i: int, tokens: list[Token]) -> None:
     in_token = find_token(tokens, i, 'in')
     colon = find_block_start(tokens, i)
     block = Block.find(tokens, i, trim_end=True)
@@ -38,7 +34,7 @@ def _fix_yield(i: int, tokens: List[Token]) -> None:
 
 def _all_isinstance(
         vals: Iterable[Any],
-        tp: Union[Type[Any], Tuple[Type[Any], ...]],
+        tp: type[Any] | tuple[type[Any], ...],
 ) -> bool:
     return all(isinstance(v, tp) for v in vals)
 
@@ -80,19 +76,19 @@ class Scope:
     def __init__(self, node: ast.AST) -> None:
         self.node = node
 
-        self.reads: Set[str] = set()
-        self.writes: Set[str] = set()
+        self.reads: set[str] = set()
+        self.writes: set[str] = set()
 
-        self.yield_from_fors: Set[Offset] = set()
-        self.yield_from_names: Dict[str, Set[Offset]]
+        self.yield_from_fors: set[Offset] = set()
+        self.yield_from_names: dict[str, set[Offset]]
         self.yield_from_names = collections.defaultdict(set)
 
 
 class Visitor(ast.NodeVisitor):
     def __init__(self) -> None:
-        self._scopes: List[Scope] = []
-        self.super_offsets: Set[Offset] = set()
-        self.yield_offsets: Set[Offset] = set()
+        self._scopes: list[Scope] = []
+        self.super_offsets: set[Offset] = set()
+        self.yield_offsets: set[Offset] = set()
 
     @contextlib.contextmanager
     def _scope(self, node: ast.AST) -> Generator[None, None, None]:
@@ -187,7 +183,7 @@ def visit_Module(
         state: State,
         node: ast.Module,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version < (3,):
         return
 

--- a/pyupgrade/_plugins/lru_cache.py
+++ b/pyupgrade/_plugins/lru_cache.py
@@ -1,9 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Optional
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -18,14 +17,14 @@ from pyupgrade._token_helpers import find_open_paren
 from pyupgrade._token_helpers import find_token
 
 
-def _remove_call(i: int, tokens: List[Token]) -> None:
+def _remove_call(i: int, tokens: list[Token]) -> None:
     i = find_open_paren(tokens, i)
     j = find_token(tokens, i, ')')
     del tokens[i:j + 1]
 
 
 def _is_literal_kwarg(
-        keyword: ast.keyword, name: str, value: Optional[bool],
+        keyword: ast.keyword, name: str, value: bool | None,
 ) -> bool:
     return (
         keyword.arg == name and
@@ -34,7 +33,7 @@ def _is_literal_kwarg(
     )
 
 
-def _eligible(keywords: List[ast.keyword]) -> bool:
+def _eligible(keywords: list[ast.keyword]) -> bool:
     if len(keywords) == 1:
         return _is_literal_kwarg(keywords[0], 'maxsize', None)
     elif len(keywords) == 2:
@@ -57,7 +56,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3, 8) and
             not node.args and

--- a/pyupgrade/_plugins/metaclass_type.py
+++ b/pyupgrade/_plugins/metaclass_type.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -13,7 +13,7 @@ from pyupgrade._data import TokenFunc
 from pyupgrade._token_helpers import find_end
 
 
-def _remove_metaclass_type(i: int, tokens: List[Token]) -> None:
+def _remove_metaclass_type(i: int, tokens: list[Token]) -> None:
     j = find_end(tokens, i)
     del tokens[i:j]
 
@@ -23,7 +23,7 @@ def visit_Assign(
         state: State,
         node: ast.Assign,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             len(node.targets) == 1 and

--- a/pyupgrade/_plugins/mock.py
+++ b/pyupgrade/_plugins/mock.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -15,7 +15,7 @@ from pyupgrade._token_helpers import find_token
 MOCK_MODULES = frozenset(('mock', 'mock.mock'))
 
 
-def _fix_import_from_mock(i: int, tokens: List[Token]) -> None:
+def _fix_import_from_mock(i: int, tokens: list[Token]) -> None:
     j = find_token(tokens, i, 'mock')
     if (
             j + 2 < len(tokens) and
@@ -29,7 +29,7 @@ def _fix_import_from_mock(i: int, tokens: List[Token]) -> None:
     tokens[j:k + 1] = [tokens[j]._replace(name='NAME', src=src)]
 
 
-def _fix_import_mock(i: int, tokens: List[Token]) -> None:
+def _fix_import_mock(i: int, tokens: list[Token]) -> None:
     j = find_token(tokens, i, 'mock')
     if (
             j + 2 < len(tokens) and
@@ -41,7 +41,7 @@ def _fix_import_mock(i: int, tokens: List[Token]) -> None:
     tokens[i:j + 1] = [tokens[j]._replace(name='NAME', src=src)]
 
 
-def _fix_mock_mock(i: int, tokens: List[Token]) -> None:
+def _fix_mock_mock(i: int, tokens: list[Token]) -> None:
     j = find_token(tokens, i + 1, 'mock')
     del tokens[i + 1:j + 1]
 
@@ -51,7 +51,7 @@ def visit_ImportFrom(
         state: State,
         node: ast.ImportFrom,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             not state.settings.keep_mock and
@@ -66,7 +66,7 @@ def visit_Import(
         state: State,
         node: ast.Import,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             not state.settings.keep_mock and
@@ -81,7 +81,7 @@ def visit_Attribute(
         state: State,
         node: ast.Attribute,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             not state.settings.keep_mock and

--- a/pyupgrade/_plugins/native_literals.py
+++ b/pyupgrade/_plugins/native_literals.py
@@ -1,9 +1,7 @@
+from __future__ import annotations
+
 import ast
-from typing import Dict
 from typing import Iterable
-from typing import List
-from typing import Set
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -21,7 +19,7 @@ from pyupgrade._token_helpers import replace_call
 SIX_NATIVE_STR = frozenset(('ensure_str', 'ensure_text', 'text_type'))
 
 
-def _fix_native_str(i: int, tokens: List[Token]) -> None:
+def _fix_native_str(i: int, tokens: list[Token]) -> None:
     j = find_open_paren(tokens, i)
     func_args, end = parse_call_args(tokens, j)
     if any(tok.name == 'NL' for tok in tokens[i:end]):
@@ -34,7 +32,7 @@ def _fix_native_str(i: int, tokens: List[Token]) -> None:
 
 def is_a_native_literal_call(
         node: ast.Call,
-        from_imports: Dict[str, Set[str]],
+        from_imports: dict[str, set[str]],
 ) -> bool:
     return (
         (
@@ -55,7 +53,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             is_a_native_literal_call(node, state.from_imports)

--- a/pyupgrade/_plugins/new_style_classes.py
+++ b/pyupgrade/_plugins/new_style_classes.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -16,7 +17,7 @@ def visit_ClassDef(
         state: State,
         node: ast.ClassDef,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version >= (3,):
         for base in node.bases:
             if isinstance(base, ast.Name) and base.id == 'object':

--- a/pyupgrade/_plugins/open_mode.py
+++ b/pyupgrade/_plugins/open_mode.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
 from typing import NamedTuple
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -29,7 +29,7 @@ class FunctionArg(NamedTuple):
     value: ast.expr
 
 
-def _fix_open_mode(i: int, tokens: List[Token], *, arg_idx: int) -> None:
+def _fix_open_mode(i: int, tokens: list[Token], *, arg_idx: int) -> None:
     j = find_open_paren(tokens, i)
     func_args, end = parse_call_args(tokens, j)
     mode = tokens_to_src(tokens[slice(*func_args[arg_idx])])
@@ -52,7 +52,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.func, ast.Name) and

--- a/pyupgrade/_plugins/oserror_aliases.py
+++ b/pyupgrade/_plugins/oserror_aliases.py
@@ -1,11 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
-from typing import Dict
 from typing import Iterable
-from typing import List
-from typing import Optional
-from typing import Set
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -25,9 +22,9 @@ ERROR_MODULES = frozenset(('mmap', 'select', 'socket'))
 
 def _fix_oserror_except(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
-        from_imports: Dict[str, Set[str]],
+        from_imports: dict[str, set[str]],
 ) -> None:
     # find all the arg strs in the tuple
     except_index = i
@@ -72,8 +69,8 @@ def _fix_oserror_except(
 
 def _is_oserror_alias(
         node: ast.AST,
-        from_imports: Dict[str, Set[str]],
-) -> Optional[Tuple[Offset, str]]:
+        from_imports: dict[str, set[str]],
+) -> tuple[Offset, str] | None:
     if isinstance(node, ast.Name) and node.id in ERROR_NAMES:
         return ast_to_offset(node), node.id
     elif (
@@ -95,8 +92,8 @@ def _is_oserror_alias(
 
 def _oserror_alias_cbs(
         node: ast.AST,
-        from_imports: Dict[str, Set[str]],
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+        from_imports: dict[str, set[str]],
+) -> Iterable[tuple[Offset, TokenFunc]]:
     offset_name = _is_oserror_alias(node, from_imports)
     if offset_name is not None:
         offset, name = offset_name
@@ -109,7 +106,7 @@ def visit_Raise(
         state: State,
         node: ast.Raise,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version >= (3,) and node.exc is not None:
         yield from _oserror_alias_cbs(node.exc, state.from_imports)
         if isinstance(node.exc, ast.Call):
@@ -121,7 +118,7 @@ def visit_Try(
         state: State,
         node: ast.Try,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version >= (3,):
         for handler in node.handlers:
             if (

--- a/pyupgrade/_plugins/percent_format.py
+++ b/pyupgrade/_plugins/percent_format.py
@@ -1,13 +1,13 @@
+from __future__ import annotations
+
 import ast
 import functools
 import re
 from typing import Generator
 from typing import Iterable
-from typing import List
 from typing import Match
 from typing import Optional
 from typing import Pattern
-from typing import Set
 from typing import Tuple
 
 from tokenize_rt import Offset
@@ -45,7 +45,7 @@ def _must_match(regex: Pattern[str], string: str, pos: int) -> Match[str]:
     return match
 
 
-def _parse_percent_format(s: str) -> Tuple[PercentFormat, ...]:
+def _parse_percent_format(s: str) -> tuple[PercentFormat, ...]:
     def _parse_inner() -> Generator[PercentFormat, None, None]:
         string_start = 0
         string_end = 0
@@ -66,7 +66,7 @@ def _parse_percent_format(s: str) -> Tuple[PercentFormat, ...]:
             else:
                 key_match = MAPPING_KEY_RE.match(s, i)
                 if key_match:
-                    key: Optional[str] = key_match.group(1)
+                    key: str | None = key_match.group(1)
                     i = key_match.end()
                 else:
                     key = None
@@ -105,7 +105,7 @@ def _parse_percent_format(s: str) -> Tuple[PercentFormat, ...]:
 
 
 def _simplify_conversion_flag(flag: str) -> str:
-    parts: List[str] = []
+    parts: list[str] = []
     for c in flag:
         if c in parts:
             continue
@@ -153,7 +153,7 @@ def _percent_to_format(s: str) -> str:
 
 def _fix_percent_format_tuple(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         node_right: ast.Tuple,
 ) -> None:
@@ -175,11 +175,11 @@ def _fix_percent_format_tuple(
 
 def _fix_percent_format_dict(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         node_right: ast.Dict,
 ) -> None:
-    seen_keys: Set[str] = set()
+    seen_keys: set[str] = set()
     keys = {}
 
     for k in node_right.keys:
@@ -234,7 +234,7 @@ def visit_BinOp(
         state: State,
         node: ast.BinOp,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             not state.settings.keep_percent_format and
             isinstance(node.op, ast.Mod) and

--- a/pyupgrade/_plugins/set_literals.py
+++ b/pyupgrade/_plugins/set_literals.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -19,7 +19,7 @@ from pyupgrade._token_helpers import victims
 SET_TRANSFORM = (ast.List, ast.ListComp, ast.GeneratorExp, ast.Tuple)
 
 
-def _fix_set_empty_literal(i: int, tokens: List[Token]) -> None:
+def _fix_set_empty_literal(i: int, tokens: list[Token]) -> None:
     # TODO: this could be implemented with a little extra logic
     if not immediately_paren('set', tokens, i):
         return
@@ -41,7 +41,7 @@ def _fix_set_empty_literal(i: int, tokens: List[Token]) -> None:
     del tokens[i + 2:j - 1]
 
 
-def _fix_set_literal(i: int, tokens: List[Token], *, arg: ast.expr) -> None:
+def _fix_set_literal(i: int, tokens: list[Token], *, arg: ast.expr) -> None:
     # TODO: this could be implemented with a little extra logic
     if not immediately_paren('set', tokens, i):
         return
@@ -63,7 +63,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             isinstance(node.func, ast.Name) and
             node.func.id == 'set' and

--- a/pyupgrade/_plugins/six_base_classes.py
+++ b/pyupgrade/_plugins/six_base_classes.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -17,7 +18,7 @@ def visit_ClassDef(
         state: State,
         node: ast.ClassDef,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version >= (3,):
         for base in node.bases:
             if is_name_attr(base, state.from_imports, 'six', ('Iterator',)):

--- a/pyupgrade/_plugins/six_calls.py
+++ b/pyupgrade/_plugins/six_calls.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 import ast
 import functools
 import sys
 from typing import Iterable
-from typing import List
-from typing import Tuple
-from typing import Type
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -15,13 +14,12 @@ from pyupgrade._ast_helpers import is_name_attr
 from pyupgrade._data import register
 from pyupgrade._data import State
 from pyupgrade._data import TokenFunc
-from pyupgrade._string_helpers import is_ascii
 from pyupgrade._token_helpers import find_and_replace_call
 from pyupgrade._token_helpers import find_open_paren
 from pyupgrade._token_helpers import parse_call_args
 from pyupgrade._token_helpers import replace_call
 
-_EXPR_NEEDS_PARENS: Tuple[Type[ast.expr], ...] = (
+_EXPR_NEEDS_PARENS: tuple[type[ast.expr], ...] = (
     ast.Await, ast.BinOp, ast.BoolOp, ast.Compare, ast.GeneratorExp, ast.IfExp,
     ast.Lambda, ast.UnaryOp,
 )
@@ -57,11 +55,11 @@ RERAISE_2_TMPL = 'raise {args[1]}.with_traceback(None)'
 RERAISE_3_TMPL = 'raise {args[1]}.with_traceback({args[2]})'
 
 
-def _fix_six_b(i: int, tokens: List[Token]) -> None:
+def _fix_six_b(i: int, tokens: list[Token]) -> None:
     j = find_open_paren(tokens, i)
     if (
             tokens[j + 1].name == 'STRING' and
-            is_ascii(tokens[j + 1].src) and
+            tokens[j + 1].src.isascii() and
             tokens[j + 2].src == ')'
     ):
         func_args, end = parse_call_args(tokens, j)
@@ -73,7 +71,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version < (3,):
         return
 
@@ -109,7 +107,7 @@ def visit_Call(
             not has_starargs(node)
     ):
         if isinstance(node.args[0], _EXPR_NEEDS_PARENS):
-            parens: Tuple[int, ...] = (0,)
+            parens: tuple[int, ...] = (0,)
         else:
             parens = ()
         func = functools.partial(

--- a/pyupgrade/_plugins/six_metaclasses.py
+++ b/pyupgrade/_plugins/six_metaclasses.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import Offset
@@ -21,7 +21,7 @@ from pyupgrade._token_helpers import remove_decorator
 from pyupgrade._token_helpers import replace_call
 
 
-def _fix_add_metaclass(i: int, tokens: List[Token]) -> None:
+def _fix_add_metaclass(i: int, tokens: list[Token]) -> None:
     j = find_open_paren(tokens, i)
     func_args, end = parse_call_args(tokens, j)
     metaclass = f'metaclass={arg_str(tokens, *func_args[0])}'
@@ -54,7 +54,7 @@ def _fix_add_metaclass(i: int, tokens: List[Token]) -> None:
     remove_decorator(i, tokens)
 
 
-def _fix_with_metaclass(i: int, tokens: List[Token]) -> None:
+def _fix_with_metaclass(i: int, tokens: list[Token]) -> None:
     j = find_open_paren(tokens, i)
     func_args, end = parse_call_args(tokens, j)
     if len(func_args) == 1:
@@ -75,7 +75,7 @@ def visit_ClassDef(
         state: State,
         node: ast.ClassDef,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version < (3,):
         return
 

--- a/pyupgrade/_plugins/six_remove_decorators.py
+++ b/pyupgrade/_plugins/six_remove_decorators.py
@@ -1,6 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -17,7 +18,7 @@ def visit_ClassDef(
         state: State,
         node: ast.ClassDef,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version >= (3,):
         for decorator in node.decorator_list:
             if is_name_attr(

--- a/pyupgrade/_plugins/six_simple.py
+++ b/pyupgrade/_plugins/six_simple.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import Optional
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -34,7 +34,7 @@ NAMES_TYPE_CTX = {
 }
 
 
-def _is_type_check(node: Optional[ast.AST]) -> bool:
+def _is_type_check(node: ast.AST | None) -> bool:
     return (
         isinstance(node, ast.Call) and
         isinstance(node.func, ast.Name) and
@@ -47,7 +47,7 @@ def visit_Attribute(
         state: State,
         node: ast.Attribute,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.value, ast.Name) and
@@ -85,7 +85,7 @@ def visit_Name(
         state: State,
         node: ast.Name,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             node.id in state.from_imports['six'] and

--- a/pyupgrade/_plugins/subprocess_run.py
+++ b/pyupgrade/_plugins/subprocess_run.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -20,7 +20,7 @@ from pyupgrade._token_helpers import replace_argument
 
 def _use_capture_output(
     i: int,
-    tokens: List[Token],
+    tokens: list[Token],
     *,
     stdout_arg_idx: int,
     stderr_arg_idx: int,
@@ -47,7 +47,7 @@ def _use_capture_output(
 
 def _replace_universal_newlines_with_text(
     i: int,
-    tokens: List[Token],
+    tokens: list[Token],
     *,
     arg_idx: int,
 ) -> None:
@@ -66,7 +66,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3, 7) and
             is_name_attr(

--- a/pyupgrade/_plugins/type_of_primitive.py
+++ b/pyupgrade/_plugins/type_of_primitive.py
@@ -1,8 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -23,7 +23,7 @@ NUM_TYPES = {
 
 def _rewrite_type_of_primitive(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         src: str,
 ) -> None:
@@ -38,7 +38,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.func, ast.Name) and

--- a/pyupgrade/_plugins/typing_pep585.py
+++ b/pyupgrade/_plugins/typing_pep585.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -31,7 +32,7 @@ def visit_Attribute(
         state: State,
         node: ast.Attribute,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             _should_rewrite(state) and
             isinstance(node.value, ast.Name) and
@@ -51,7 +52,7 @@ def visit_Name(
         state: State,
         node: ast.Name,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             _should_rewrite(state) and
             node.id in state.from_imports['typing'] and

--- a/pyupgrade/_plugins/typing_pep604.py
+++ b/pyupgrade/_plugins/typing_pep604.py
@@ -1,9 +1,9 @@
+from __future__ import annotations
+
 import ast
 import functools
 import sys
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import Offset
@@ -20,7 +20,7 @@ from pyupgrade._token_helpers import find_token
 from pyupgrade._token_helpers import OPENING
 
 
-def _fix_optional(i: int, tokens: List[Token]) -> None:
+def _fix_optional(i: int, tokens: list[Token]) -> None:
     j = find_token(tokens, i, '[')
     k = find_closing_bracket(tokens, j)
     if tokens[j].line == tokens[k].line:
@@ -34,7 +34,7 @@ def _fix_optional(i: int, tokens: List[Token]) -> None:
 
 def _fix_union(
         i: int,
-        tokens: List[Token],
+        tokens: list[Token],
         *,
         arg_count: int,
 ) -> None:
@@ -140,7 +140,7 @@ def visit_Subscript(
         state: State,
         node: ast.Subscript,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if not _supported_version(state):
         return
 

--- a/pyupgrade/_plugins/typing_text.py
+++ b/pyupgrade/_plugins/typing_text.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -17,7 +18,7 @@ def visit_Attribute(
         state: State,
         node: ast.Attribute,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             isinstance(node.value, ast.Name) and
@@ -37,7 +38,7 @@ def visit_Name(
         state: State,
         node: ast.Name,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             node.id in state.from_imports['typing'] and

--- a/pyupgrade/_plugins/unittest_aliases.py
+++ b/pyupgrade/_plugins/unittest_aliases.py
@@ -1,7 +1,8 @@
+from __future__ import annotations
+
 import ast
 import functools
 from typing import Iterable
-from typing import Tuple
 
 from tokenize_rt import Offset
 
@@ -40,7 +41,7 @@ def visit_Call(
         state: State,
         node: ast.Call,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if state.settings.min_version >= (3,):
         method_mapping = METHOD_MAPPING_PY35_PLUS
     else:

--- a/pyupgrade/_plugins/unpack_list_comprehension.py
+++ b/pyupgrade/_plugins/unpack_list_comprehension.py
@@ -1,7 +1,7 @@
+from __future__ import annotations
+
 import ast
 from typing import Iterable
-from typing import List
-from typing import Tuple
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -15,7 +15,7 @@ from pyupgrade._token_helpers import find_closing_bracket
 from pyupgrade._token_helpers import find_comprehension_opening_bracket
 
 
-def _replace_list_comprehension(i: int, tokens: List[Token]) -> None:
+def _replace_list_comprehension(i: int, tokens: list[Token]) -> None:
     start = find_comprehension_opening_bracket(i, tokens)
     end = find_closing_bracket(tokens, start)
     tokens[start] = tokens[start]._replace(src='(')
@@ -27,7 +27,7 @@ def visit_Assign(
         state: State,
         node: ast.Assign,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
             len(node.targets) == 1 and

--- a/pyupgrade/_plugins/versioned_branches.py
+++ b/pyupgrade/_plugins/versioned_branches.py
@@ -1,10 +1,9 @@
+from __future__ import annotations
+
 import ast
 from typing import cast
 from typing import Iterable
 from typing import List
-from typing import Tuple
-from typing import Type
-from typing import Union
 
 from tokenize_rt import Offset
 from tokenize_rt import Token
@@ -18,7 +17,7 @@ from pyupgrade._data import Version
 from pyupgrade._token_helpers import Block
 
 
-def _find_if_else_block(tokens: List[Token], i: int) -> Tuple[Block, Block]:
+def _find_if_else_block(tokens: list[Token], i: int) -> tuple[Block, Block]:
     if_block = Block.find(tokens, i)
     i = if_block.end
     while tokens[i].src != 'else':
@@ -27,13 +26,13 @@ def _find_if_else_block(tokens: List[Token], i: int) -> Tuple[Block, Block]:
     return if_block, else_block
 
 
-def _find_elif(tokens: List[Token], i: int) -> int:
+def _find_elif(tokens: list[Token], i: int) -> int:
     while tokens[i].src != 'elif':  # pragma: no cover (only for <3.8.1)
         i -= 1
     return i
 
 
-def _fix_py3_block(i: int, tokens: List[Token]) -> None:
+def _fix_py3_block(i: int, tokens: list[Token]) -> None:
     if tokens[i].src == 'if':
         if_block = Block.find(tokens, i)
         if_block.dedent(tokens)
@@ -43,7 +42,7 @@ def _fix_py3_block(i: int, tokens: List[Token]) -> None:
         if_block.replace_condition(tokens, [Token('NAME', 'else')])
 
 
-def _fix_py2_block(i: int, tokens: List[Token]) -> None:
+def _fix_py2_block(i: int, tokens: list[Token]) -> None:
     if tokens[i].src == 'if':
         if_block, else_block = _find_if_else_block(tokens, i)
         else_block.dedent(tokens)
@@ -54,7 +53,7 @@ def _fix_py2_block(i: int, tokens: List[Token]) -> None:
         del tokens[if_block.start:else_block.start]
 
 
-def _fix_py3_block_else(i: int, tokens: List[Token]) -> None:
+def _fix_py3_block_else(i: int, tokens: list[Token]) -> None:
     if tokens[i].src == 'if':
         if_block, else_block = _find_if_else_block(tokens, i)
         if_block.dedent(tokens)
@@ -77,7 +76,7 @@ def _eq(test: ast.Compare, n: int) -> bool:
 
 def _compare_to_3(
     test: ast.Compare,
-    op: Union[Type[ast.cmpop], Tuple[Type[ast.cmpop], ...]],
+    op: type[ast.cmpop] | tuple[type[ast.cmpop], ...],
     minor: int = 0,
 ) -> bool:
     if not (
@@ -101,7 +100,7 @@ def visit_If(
         state: State,
         node: ast.If,
         parent: ast.AST,
-) -> Iterable[Tuple[Offset, TokenFunc]]:
+) -> Iterable[tuple[Offset, TokenFunc]]:
 
     min_version: Version
     if state.settings.min_version == (3,):

--- a/pyupgrade/_string_helpers.py
+++ b/pyupgrade/_string_helpers.py
@@ -1,13 +1,7 @@
+from __future__ import annotations
+
 import codecs
 import re
-import string
-import sys
-
-if sys.version_info >= (3, 7):  # pragma: >=3.7 cover
-    is_ascii = str.isascii
-else:  # pragma: <3.7 cover
-    def is_ascii(s: str) -> bool:
-        return all(c in string.printable for c in s)
 
 NAMED_UNICODE_RE = re.compile(r'(?<!\\)(?:\\\\)*(\\N\{[^}]+\})')
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,7 +13,6 @@ classifiers =
     License :: OSI Approved :: MIT License
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
@@ -25,7 +24,7 @@ classifiers =
 packages = find:
 install_requires =
     tokenize-rt>=3.2.0
-python_requires = >=3.6.1
+python_requires = >=3.7
 
 [options.packages.find]
 exclude =

--- a/setup.py
+++ b/setup.py
@@ -1,2 +1,4 @@
+from __future__ import annotations
+
 from setuptools import setup
 setup()

--- a/tests/_plugins/typing_pep604_test.py
+++ b/tests/_plugins/typing_pep604_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 from tokenize_rt import src_to_tokens
 from tokenize_rt import tokens_to_src

--- a/tests/features/abspath_file_test.py
+++ b/tests/features/abspath_file_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/binary_literals_test.py
+++ b/tests/features/binary_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/c_element_tree_test.py
+++ b/tests/features/c_element_tree_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/capture_output_test.py
+++ b/tests/features/capture_output_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/default_encoding_test.py
+++ b/tests/features/default_encoding_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/dict_literals_test.py
+++ b/tests/features/dict_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/encoding_cookie_test.py
+++ b/tests/features/encoding_cookie_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/escape_sequences_test.py
+++ b/tests/features/escape_sequences_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/extra_parens_test.py
+++ b/tests/features/extra_parens_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/format_literals_test.py
+++ b/tests/features/format_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/format_locals_test.py
+++ b/tests/features/format_locals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/fstrings_test.py
+++ b/tests/features/fstrings_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_py36_plus

--- a/tests/features/generator_expressions_pep289_test.py
+++ b/tests/features/generator_expressions_pep289_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/import_removals_test.py
+++ b/tests/features/import_removals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/imports_future_test.py
+++ b/tests/features/imports_future_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _imports_future

--- a/tests/features/io_open_test.py
+++ b/tests/features/io_open_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/long_literals_test.py
+++ b/tests/features/long_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/lru_cache_test.py
+++ b/tests/features/lru_cache_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/metaclass_type_test.py
+++ b/tests/features/metaclass_type_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/mock_test.py
+++ b/tests/features/mock_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/native_literals_test.py
+++ b/tests/features/native_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/new_style_classes_test.py
+++ b/tests/features/new_style_classes_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/octal_literals_test.py
+++ b/tests/features/octal_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/open_mode_test.py
+++ b/tests/features/open_mode_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/oserror_aliases_test.py
+++ b/tests/features/oserror_aliases_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/percent_format_test.py
+++ b/tests/features/percent_format_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 
 import pytest

--- a/tests/features/raw_unicode_literals_test.py
+++ b/tests/features/raw_unicode_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/set_literals_test.py
+++ b/tests/features/set_literals_test.py
@@ -1,4 +1,4 @@
-import sys
+from __future__ import annotations
 
 import pytest
 
@@ -95,25 +95,5 @@ def test_fix_sets_noop(s):
     ),
 )
 def test_sets(s, expected):
-    ret = _fix_plugins(s, settings=Settings())
-    assert ret == expected
-
-
-@pytest.mark.xfail(sys.version_info >= (3, 7), reason='genexp trailing comma')
-@pytest.mark.parametrize(
-    ('s', 'expected'),
-    (
-        ('set(x for x in y,)', '{x for x in y}'),
-        (
-            'set(\n'
-            '    x for x in y,\n'
-            ')',
-            '{\n'
-            '    x for x in y\n'
-            '}',
-        ),
-    ),
-)
-def test_sets_generators_trailing_commas(s, expected):
     ret = _fix_plugins(s, settings=Settings())
     assert ret == expected

--- a/tests/features/six_b_test.py
+++ b/tests/features/six_b_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/six_remove_decorators_test.py
+++ b/tests/features/six_remove_decorators_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/six_simple_test.py
+++ b/tests/features/six_simple_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/six_test.py
+++ b/tests/features/six_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/features/super_test.py
+++ b/tests/features/super_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_plugins

--- a/tests/features/type_of_primitive_test.py
+++ b/tests/features/type_of_primitive_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/typing_named_tuple_test.py
+++ b/tests/features/typing_named_tuple_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_py36_plus

--- a/tests/features/typing_pep563_test.py
+++ b/tests/features/typing_pep563_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sys
 
 import pytest

--- a/tests/features/typing_pep585_test.py
+++ b/tests/features/typing_pep585_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/typing_pep604_test.py
+++ b/tests/features/typing_pep604_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/typing_text_test.py
+++ b/tests/features/typing_text_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/typing_typed_dict_test.py
+++ b/tests/features/typing_typed_dict_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_py36_plus

--- a/tests/features/unicode_literals_test.py
+++ b/tests/features/unicode_literals_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._main import _fix_tokens

--- a/tests/features/unittest_aliases_test.py
+++ b/tests/features/unittest_aliases_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/universal_newlines_to_text_test.py
+++ b/tests/features/universal_newlines_to_text_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/unpack_list_comprehension_test.py
+++ b/tests/features/unpack_list_comprehension_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/versioned_branches_test.py
+++ b/tests/features/versioned_branches_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 
 from pyupgrade._data import Settings

--- a/tests/features/yield_from_test.py
+++ b/tests/features/yield_from_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import ast
 
 import pytest

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import io
 import re
 import sys

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py36,py37,py38,py39,pypy3,pre-commit
+envlist = py37,py38,py39,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
python 3.6 reached end of life on 2021-12-23

Committed via https://github.com/asottile/all-repos