### PR TITLE
Add rewriting of if expressions

### DIFF
--- a/tests/features/versioned_branches_test.py
+++ b/tests/features/versioned_branches_test.py
@@ -446,6 +446,11 @@ def test_fix_py2_block_noop(s):
 
             id='comment after dedented block',
         ),
+        pytest.param(
+            'my_var = 1 if six.PY2 else 2\n',
+            'my_var = 2\n',
+            id='if-expression',
+        ),
     ),
 )
 def test_fix_py2_blocks(s, expected):


### PR DESCRIPTION
Only handle the case where we keep the `else` branch,
as that provides an ending-delimiter before which we remove all tokens.

Part of https://github.com/asottile/pyupgrade/issues/162.