### PR TITLE
rewrite collections imports for ABC classes to collections.abc

### DIFF
--- a/README.md
+++ b/README.md
@@ -632,6 +632,60 @@ Availability:
 +float
 ```
 
+### Rewrite imports of ABC from `collections`
+
+Availability:
+- `--py3` is passed on the commandline.
+
+```diff
+-from collections import Hashable
++from collections.abc import Hashable
+-from collections import Awaitable
++from collections.abc import Awaitable
+-from collections import Coroutine
++from collections.abc import Coroutine
+-from collections import AsyncIterable
++from collections.abc import AsyncIterable
+-from collections import AsyncIterator
++from collections.abc import AsyncIterator
+-from collections import Iterable
++from collections.abc import Iterable
+-from collections import Iterator
++from collections.abc import Iterator
+-from collections import Reversible
++from collections.abc import Reversible
+-from collections import Sized
++from collections.abc import Sized
+-from collections import Container
++from collections.abc import Container
+-from collections import Collection
++from collections.abc import Collection
+-from collections import MutableSet
++from collections.abc import MutableSet
+-from collections import Mapping
++from collections.abc import Mapping
+-from collections import MutableMapping
++from collections.abc import MutableMapping
+-from collections import Sequence
++from collections.abc import Sequence
+-from collections import MutableSequence
++from collections.abc import MutableSequence
+-from collections import ByteString
++from collections.abc import ByteString
+-from collections import MappingView
++from collections.abc import MappingView
+-from collections import KeysView
++from collections.abc import KeysView
+-from collections import ItemsView
++from collections.abc import ItemsView
+-from collections import ValuesView
++from collections.abc import ValuesView
+-from collections import Generator
++from collections.abc import Generator
+-from collections import AsyncGenerator
++from collections.abc import AsyncGenerator
+```
+
 ### `typing.NamedTuple` / `typing.TypedDict` py36+ syntax
 
 Availability:

--- a/pyupgrade/_plugins/collections_abc.py
+++ b/pyupgrade/_plugins/collections_abc.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import ast
+from typing import Iterable
+
+from tokenize_rt import Offset
+from tokenize_rt import Token
+
+from pyupgrade._ast_helpers import ast_to_offset
+from pyupgrade._data import register
+from pyupgrade._data import State
+from pyupgrade._data import TokenFunc
+from pyupgrade._token_helpers import find_token
+
+COLLECTIONS_MODULE = 'collections'
+ABC_CLASSES = {
+    'Hashable',
+    'Awaitable',
+    'Coroutine',
+    'AsyncIterable',
+    'AsyncIterator',
+    'Iterable',
+    'Iterator',
+    'Reversible',
+    'Sized',
+    'Container',
+    'Collection',
+    'MutableSet',
+    'Mapping',
+    'MutableMapping',
+    'Sequence',
+    'MutableSequence',
+    'ByteString',
+    'MappingView',
+    'KeysView',
+    'ItemsView',
+    'ValuesView',
+    'Generator',
+    'AsyncGenerator',
+}
+
+
+def _fix_import_from_collections(i: int, tokens: list[Token]) -> None:
+    j = find_token(tokens, i, 'collections')
+    src = 'collections.abc'
+    tokens[j] = tokens[j]._replace(name='NAME', src=src)
+
+
+@register(ast.ImportFrom)
+def visit_ImportFrom(
+        state: State,
+        node: ast.ImportFrom,
+        parent: ast.AST,
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+            state.settings.min_version >= (3,) and
+            not state.settings.keep_mock and
+            not node.level and
+            node.module == COLLECTIONS_MODULE and
+            all(alias.name in ABC_CLASSES for alias in node.names)
+    ):
+        yield ast_to_offset(node), _fix_import_from_collections

--- a/tests/features/collections_abc_test.py
+++ b/tests/features/collections_abc_test.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import pytest
+
+from pyupgrade._data import Settings
+from pyupgrade._main import _fix_plugins
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        pytest.param(
+            'import contextlib, collections, sys\n',
+            id='does not rewrite multiple imports',
+        ),
+        pytest.param(
+            'from collections import Generator, defaultdict\n',
+            id='does not rewrite imports with mix of abc and concrete',
+        ),
+        pytest.param(
+            'from .collections import Generator\n',
+            id='leave relative imports alone',
+        ),
+        pytest.param(
+            'from collections.abc import Generator\n',
+            id='leave already modified alone',
+        ),
+    ),
+)
+def test_collections_abc_noop(s):
+    assert _fix_plugins(s, settings=Settings(min_version=(3,))) == s
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        pytest.param(
+            'from collections import Generator\n'
+            '\n'
+            'isinstance(g, Generator)',
+            'from collections.abc import Generator\n'
+            '\n'
+            'isinstance(g, Generator)',
+            id='relative import class',
+        ),
+        pytest.param(
+            'from collections import Generator, Awaitable, KeysView\n'
+            '\n'
+            'isinstance(g, collections.Generator)\n'
+            'isinstance(a, collections.Awaitable)\n'
+            'isinstance(kv, collections.KeysView)\n',
+            'from collections.abc import Generator, Awaitable, KeysView\n'
+            '\n'
+            'isinstance(g, collections.Generator)\n'
+            'isinstance(a, collections.Awaitable)\n'
+            'isinstance(kv, collections.KeysView)\n',
+            id='multiple relative import classes',
+        ),
+    ),
+)
+def test_fix_collections_abc_imports(s, expected):
+    assert _fix_plugins(s, settings=Settings(min_version=(3,))) == expected


### PR DESCRIPTION
Ref #606 

- [x] rewrite imports when all imported classes are ABC
- [x] document the feature in the README

I'm tempted to leave Ithe 2 more complex cases out for now:

- [ ] support mix of ABC and non-ABC imported classes?
- [ ] support absolute import?

Thoughts?