### PR TITLE
Add Python version setting example for config

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Sample `.pre-commit-config.yaml`:
     rev: v2.32.1
     hooks:
     -   id: pyupgrade
+        args: [--py310-plus]  # Optional
 ```
 
 ## Implemented features


### PR DESCRIPTION
I thought it's better to have the example target Python version setting in the readme.