### PR TITLE
rewrite bytes(b'foo') to b'foo'

### DIFF
--- a/pyupgrade/_token_helpers.py
+++ b/pyupgrade/_token_helpers.py
@@ -420,7 +420,7 @@ def replace_call(
 
     # there are a few edge cases which cause syntax errors when the first
     # argument contains newlines (especially when moved outside of a natural
-    # contiunuation context)
+    # continuation context)
     if _arg_contains_newline(tokens, *args[0]) and 0 not in parens:
         # this attempts to preserve more of the whitespace by using the
         # original non-stripped argument string

--- a/tests/features/native_literals_test.py
+++ b/tests/features/native_literals_test.py
@@ -14,6 +14,11 @@ from pyupgrade._main import _fix_plugins
         'str(*a)', 'str("foo", *a)',
         'str(**k)', 'str("foo", **k)',
         'str("foo", encoding="UTF-8")',
+        'bytes("foo", encoding="UTF-8")',
+        'bytes(b"foo"\nb"bar")',
+        'bytes("foo"\n"bar")',
+        'bytes(*a)', 'bytes("foo", *a)',
+        'bytes("foo", **a)',
     ),
 )
 def test_fix_native_literals_noop(s):
@@ -38,6 +43,9 @@ def test_fix_native_literals_noop(s):
 
             id='from import of rewritten name',
         ),
+        ('bytes()', "b''"),
+        ('bytes(b"foo")', 'b"foo"'),
+        ('bytes(b"""\nfoo""")', 'b"""\nfoo"""'),
     ),
 )
 def test_fix_native_literals(s, expected):


### PR DESCRIPTION
resolves #649

I unfortunatelly have to check `node.func.id == 'bytes'` twice, to later narrow it down so that the Call name is `bytes` **while** the arg is `ast.Bytes`. But for some reason mypy is mad at the second check with:
```
pyupgrade/_plugins/native_literals.py:56: error: "expr" has no attribute "id"
Found 1 error in 1 file (checked 95 source files)
```
could you give me a hint what's wrong there?

also not sure if the rename of the `_fix_native_str` function is okay since it now also handles bytes?
