### PR TITLE
fix imports removal not including rules from previous versions

### DIFF
--- a/pyupgrade/_plugins/imports.py
+++ b/pyupgrade/_plugins/imports.py
@@ -233,10 +233,11 @@ def _for_version(
         Mapping[tuple[str, str], str],
         Mapping[str, str],
 ]:
-    removals = {}
+    removals = collections.defaultdict(set)
     for ver, ver_removals in REMOVALS.items():
         if ver <= version:
-            removals.update(ver_removals)
+            for base, names in ver_removals.items():
+                removals[base].update(names)
 
     exact = {}
     for ver, ver_exact in REPLACE_EXACT.items():

--- a/tests/features/import_removals_test.py
+++ b/tests/features/import_removals_test.py
@@ -39,6 +39,7 @@ def test_import_removals_noop(s, min_version):
         ('from __future__ import division\n', (3,), ''),
         ('from __future__ import division\n', (3, 6), ''),
         ('from __future__ import (generators,)', (2, 7), ''),
+        ('from __future__ import print_function', (3, 8), ''),
         ('from builtins import map', (3,), ''),
         ('from builtins import *', (3,), ''),
         ('from six.moves import map', (3,), ''),


### PR DESCRIPTION
reported by `bork` in [discord](https://discord.com/channels/576802746850869258/747133137804591156/1001211167114530856)

when using `--py38-plus` (or any other mode which is a superset of `py3-plus`), most of the imports were not removed
```python
$ cat t.py
from __future__ import print_function

pass
$ pyupgrade --py38-plus t.py
$ cat t.py
from __future__ import print_function

pass
$ pyupgrade --py3-plus t.py
Rewriting t.py
$ cat t.py
pass
```
introduced by refactoring in https://github.com/asottile/pyupgrade/commit/4775ca8ad7cac72dc8dd5c6bcd29defd2d375cbb

added a test-case