### PR TITLE
Add ast.Bytes in typing_classes _unparse

### DIFF
--- a/pyupgrade/_plugins/typing_classes.py
+++ b/pyupgrade/_plugins/typing_classes.py
@@ -38,7 +38,7 @@ def _unparse(node: ast.expr) -> str:
         else:
             slice_s = _unparse(node_slice)
         return f'{_unparse(node.value)}[{slice_s}]'
-    elif isinstance(node, ast.Str):
+    elif isinstance(node, (ast.Str, ast.Bytes)):
         return repr(node.s)
     elif isinstance(node, ast.Ellipsis):
         return '...'

--- a/tests/features/typing_classes_test.py
+++ b/tests/features/typing_classes_test.py
@@ -297,6 +297,16 @@ def test_typing_typed_dict_noop(s):
         ),
         pytest.param(
             'import typing\n'
+            'D = typing.TypedDict("D", {"a": typing.Literal["b", b"c"]})\n',
+
+            'import typing\n'
+            'class D(typing.TypedDict):\n'
+            "    a: typing.Literal['b', b'c']\n",
+
+            id='with Literal of bytes',
+        ),
+        pytest.param(
+            'import typing\n'
             'D = typing.TypedDict("D", {"a": int}, total=False)\n',
 
             'import typing\n'


### PR DESCRIPTION
Hi, I appreciate your work on this project. Our transition to Python 3.10 was seamless thanks to it.

There was a problem running pyupgrade on our codebase.

The following statement was acceptable:
`D = typing.TypedDict("D", {"a": typing.Literal["b", "c"]})`

But, the these statements raise a `NotImplementedError: Constant(value=*)` error, causing Pyupgrade to crash:
- `D = typing.TypedDict("D", {"a": typing.Literal[1, 2]})`
- `D = typing.TypedDict("D", {"a": typing.Literal[b"b", b"c"]})`