### PR TITLE
limit tokenize-rt to <4 before breaks

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    tokenize-rt>=3.2.0
+    tokenize-rt<4
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
tokenze-rt will remove python2-compat parsing