### PR TITLE
Add flags for keep-open-mode and keep-format-indices

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,9 @@ Sample `.pre-commit-config.yaml`:
 
 ### Python2.7+ Format Specifiers
 
+Availability:
+- Unless `--keep-format-indices` is passed.
+
 ```diff
 -'{0} {1}'.format(1, 2)
 +'{} {}'.format(1, 2)
@@ -550,6 +553,8 @@ Availability:
 
 Availability:
 - `--py3-plus` is passed on the commandline.
+  - Unless `--keep-open-mode` is passed.
+
 
 ```diff
 -open("foo", "U")

--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -29,6 +29,7 @@ class Settings(NamedTuple):
     keep_percent_format: bool = False
     keep_mock: bool = False
     keep_runtime_typing: bool = False
+    keep_open_mode: bool = False
 
 
 class State(NamedTuple):

--- a/pyupgrade/_plugins/open_mode.py
+++ b/pyupgrade/_plugins/open_mode.py
@@ -55,6 +55,7 @@ def visit_Call(
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
             state.settings.min_version >= (3,) and
+            not state.settings.keep_open_mode and
             (
                 (
                     isinstance(node.func, ast.Name) and

--- a/tests/features/format_literals_test.py
+++ b/tests/features/format_literals_test.py
@@ -32,6 +32,11 @@ def test_format_literals_noop(s):
     assert _fix_tokens(s, min_version=(2, 7)) == s
 
 
+def test_format_literals_noop_keep_format_indices():
+    s = '"{0}".format(1)'
+    assert _fix_tokens(s, min_version=(2, 7), keep_format_indices=True) == s
+
+
 @pytest.mark.parametrize(
     ('s', 'expected'),
     (

--- a/tests/features/open_mode_test.py
+++ b/tests/features/open_mode_test.py
@@ -28,6 +28,13 @@ def test_fix_open_mode_noop(s):
     assert _fix_plugins(s, settings=Settings(min_version=(3,))) == s
 
 
+def test_open_mode_noop_keep_open_mode():
+    """This would've been rewritten if keep_mock were False"""
+    s = 'open("foo", mode="r")'
+    settings = Settings(min_version=(3,), keep_open_mode=True)
+    assert _fix_plugins(s, settings=settings) == s
+
+
 @pytest.mark.parametrize(
     ('s', 'expected'),
     (


### PR DESCRIPTION
Some of our users will prefer to be explicit. How do you feel about adding these switches?