### PR TITLE
CI: Add Python 3.10 and 3.11 to Tox configuration and Azure pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ resources:
       type: github
       endpoint: github
       name: asottile/azure-pipeline-templates
-      ref: refs/tags/v2.4.1
+      ref: refs/tags/v2.4.2
 
 jobs:
 - template: job--python-tox.yml@asottile
@@ -19,5 +19,5 @@ jobs:
     os: windows
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py37, py38, py39, py310]
+    toxenvs: [py37, py38, py39, py310, py311]
     os: linux

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,5 +19,5 @@ jobs:
     os: windows
 - template: job--python-tox.yml@asottile
   parameters:
-    toxenvs: [py37, py38, py39]
+    toxenvs: [py37, py38, py39, py310]
     os: linux

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,pypy3,pre-commit
+envlist = py37,py38,py39,py310,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37,py38,py39,py310,pypy3,pre-commit
+envlist = py37,py38,py39,py310,py311,pypy3,pre-commit
 
 [testenv]
 deps = -rrequirements-dev.txt


### PR DESCRIPTION
This PR adds add a Python 3.10 and 3.11 jobs to the Tox configuration and to the Azure pipeline CI configuration. It also updates the [azure-pipeline-templates](https://github.com/asottile/azure-pipeline-templates) to the latest version, [v2.4.2](https://github.com/asottile/azure-pipeline-templates/releases/tag/v2.4.2).

Python 3.11 is now in the release candidate phase, and ABI stable.

The two commits to update to 3.10 and 3.11 can be squashed if preferred, or kept as separate commits.