### PR TITLE
setup.cfg: Add project_urls for PyPI with links to funding, source code and issue tracker pages

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,10 @@ classifiers =
     Programming Language :: Python :: 3 :: Only
     Programming Language :: Python :: Implementation :: CPython
     Programming Language :: Python :: Implementation :: PyPy
+project_urls =
+    Funding = https://github.com/sponsors/asottile
+    Source = https://github.com/asottile/pyupgrade
+    Tracker = https://github.com/asottile/pyupgrade/issues
 
 [options]
 packages = find:


### PR DESCRIPTION
Add [`project_urls`](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls) to setup.cfg with URLs to the pyupgrade funding page, source code and bug tracker. This will add those URLs under the "Project links" section on https://pypi.org/project/pyupgrade, making it easy to find these resources directly from PyPI.