### PR TITLE
Enable an option to disable open mode

### DIFF
--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -29,6 +29,7 @@ class Settings(NamedTuple):
     keep_percent_format: bool = False
     keep_mock: bool = False
     keep_runtime_typing: bool = False
+    disable_redundant_open_mode: bool = False
 
 
 class State(NamedTuple):

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -322,6 +322,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
             keep_percent_format=args.keep_percent_format,
             keep_mock=args.keep_mock,
             keep_runtime_typing=args.keep_runtime_typing,
+            disable_redundant_open_mode=args.disable_redundant_open_mode,
         ),
     )
     contents_text = _fix_tokens(contents_text)
@@ -346,6 +347,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
     parser.add_argument('--keep-runtime-typing', action='store_true')
+    parser.add_argument('--disable-redundant-open-mode', action='store_true')
     parser.add_argument(
         '--py3-plus', '--py3-only',
         action='store_const', dest='min_version', default=(3,), const=(3,),

--- a/pyupgrade/_plugins/open_mode.py
+++ b/pyupgrade/_plugins/open_mode.py
@@ -67,6 +67,8 @@ def visit_Call(
         node: ast.Call,
         parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
+    if state.settings.disable_redundant_open_mode:
+        return
     if (
             (
                 (

--- a/tests/features/open_mode_test.py
+++ b/tests/features/open_mode_test.py
@@ -38,6 +38,13 @@ def test_fix_open_mode_noop(s):
     assert _fix_plugins(s, settings=Settings()) == s
 
 
+def test_disable_redundant_open_mode_noop():
+    s = '''\
+with open("foobar.txt", "r")
+'''
+    assert _fix_plugins(s, settings=Settings(disable_redundant_open_mode=True)) == s
+
+
 @pytest.mark.parametrize(
     ('s', 'expected'),
     (


### PR DESCRIPTION
This merge request adds the "--disable-redundant-open-mode" argument as an opt-in option for this pre-commit hook.

It disables the open_mode part of the plugin.

My team, myself included, would like to keep the redudant "r" read flag when using open.