### PR TITLE
Fix `Optional["ForwardRef"]` rewriting

### DIFF
--- a/pyupgrade/_plugins/typing_pep604.py
+++ b/pyupgrade/_plugins/typing_pep604.py
@@ -144,16 +144,17 @@ def visit_Subscript(
     if not _supported_version(state):
         return
 
-    # prevent rewriting forward annotations
-    if (
-            (sys.version_info >= (3, 9) and _any_arg_is_str(node.slice)) or
-            (
-                sys.version_info < (3, 9) and
-                isinstance(node.slice, ast.Index) and
-                _any_arg_is_str(node.slice.value)
-            )
-    ):
-        return
+    # don't rewrite forward annotations (unless we know they will be dequoted)
+    if 'annotations' not in state.from_imports['__future__']:
+        if (
+                (sys.version_info >= (3, 9) and _any_arg_is_str(node.slice)) or
+                (
+                    sys.version_info < (3, 9) and
+                    isinstance(node.slice, ast.Index) and
+                    _any_arg_is_str(node.slice.value)
+                )
+        ):
+            return
 
     if is_name_attr(
             node.value,

--- a/tests/features/typing_pep604_test.py
+++ b/tests/features/typing_pep604_test.py
@@ -186,6 +186,17 @@ def f(x: int | str) -> None: ...
             id='Optional rewrite multi-line',
         ),
         pytest.param(
+            'from __future__ import annotations\n'
+            'from typing import Optional\n'
+            'x: Optional["str"]\n',
+
+            'from __future__ import annotations\n'
+            'from typing import Optional\n'
+            'x: str | None\n',
+
+            id='Optional rewrite with forward reference',
+        ),
+        pytest.param(
             'from typing import Union, Sequence\n'
             'def f(x: Union[Union[A, B], Sequence[Union[C, D]]]): pass\n',
 


### PR DESCRIPTION
`Optional["ForwardRef"]` currently requires two `pyupgrade` calls to be fully rewritten. Here's a minimal example:

```shell
$ echo "from __future__ import annotations; from typing import Optional; x: Optional['str']" > repro.py

$ pyupgrade --py39-plus repro.py; cat repro.py
Rewriting repro.py
from __future__ import annotations; from typing import Optional; x: Optional[str]

$ pyupgrade --py39-plus repro.py; cat repro.py
Rewriting repro.py
from __future__ import annotations; from typing import Optional; x: str | None
```

The problem here is that `typing_pep604.py` bails if it encounters a forward annotation (https://github.com/asottile/pyupgrade/issues/567). This PR adjusts the check to guess ahead if annotations will be dequoted by `typing_pep563.py`. 

I guess there's an argument to be made that forward refs and `from __future__ import annotations` in the same file aren't best practice to begin with, but I've encountered that in real-world code and figured I'd send a fix. No hard feelings if you consider this a wontfix. :)