### PR TITLE
Enable linting of stub files (`.pyi`) in pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,5 @@
     description: Automatically upgrade syntax for newer versions.
     entry: pyupgrade
     language: python
-    types: [python]
-    # for backward compatibility
-    files: ''
-    minimum_pre_commit_version: 0.15.0
+    types_or: [python, pyi]
+    minimum_pre_commit_version: 2.9.2


### PR DESCRIPTION
Enable support for `pyi` files when using `pyupgrade` through `pre-commit`. This will run pyupgrade on stub files in addition to source files.

References:
1. [The same file on black](https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml)
2. [pre-commit docs](https://github.com/psf/black/blob/main/.pre-commit-hooks.yaml)
3. [Same PR on flake8](https://github.com/PyCQA/flake8/pull/1773)
4. [Same PR on absolufy-imports](https://github.com/MarcoGorelli/absolufy-imports/pull/77)