### PR TITLE
Directory or Files Walker

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -340,12 +340,13 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
         return contents_text != contents_text_orig
 
 
-blacklist = {".tox", "venv", "site-packages", ".eggs"}
+blacklist = {'.tox', 'venv', 'site-packages', '.eggs'}
 
 
 def _resolve_files(
         files_or_paths,
-        excluded_files_or_paths):
+        excluded_files_or_paths,
+):
     """Resolve relative paths and directory names into a list of absolute paths to python files."""
     # Taken from https://github.com/ikamensh/flynt (MIT)
     files = []
@@ -359,7 +360,7 @@ def _resolve_files(
         abs_path = os.path.abspath(file_or_path)
 
         if not os.path.exists(abs_path):
-            print(f"`{file_or_path}` not found")
+            print(f'`{file_or_path}` not found')
             sys.exit(1)
 
         if os.path.isdir(abs_path):
@@ -409,7 +410,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     )
     args = parser.parse_args(argv)
     ret = 0
-    for filename in _resolve_files(args.filenames,[]):
+    for filename in _resolve_files(args.filenames, []):
         ret |= _fix_file(filename, args)
     return ret
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,8 +19,8 @@ classifiers =
 [options]
 packages = find:
 install_requires =
-    tokenize-rt>=3.2.0
     astor
+    tokenize-rt>=3.2.0
 python_requires = >=3.7
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ classifiers =
 packages = find:
 install_requires =
     tokenize-rt>=3.2.0
+    "astor",
 python_requires = >=3.7
 
 [options.packages.find]

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ classifiers =
 packages = find:
 install_requires =
     tokenize-rt>=3.2.0
-    "astor",
+    astor
 python_requires = >=3.7
 
 [options.packages.find]


### PR DESCRIPTION
`pyupgrade --py36-plus .`

```
PS C:\Users\Tat\PycharmProjects\meerk40t> pyupgrade --py36-plus .
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\translate.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\kernelserver.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\main.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\svgelements.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\balormk\controller.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\balormk\device.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\camera\plugin.py
Rewriting C:\Users\Tat\PycharmProjects\meerk40t\meerk40t\core\elements.py
...
```

Other tools let you specify a directory. Like flynt (https://github.com/ikamensh/flynt) which I went to and stole the relevant function and commented that I stole it from some MIT licensed code. Doing this yourself without the weird dependency (I don't know what astor even does) is fine. But, the lack of specifying a directory and the prospect of indexing each file was pretty annoying (I have like 300 files).

If you somehow can walk directories and it's somehow not evident from the source or documentation, please update the documentation instead.