### PR TITLE
Ensure typing_pep585 only gets applied on py3.9+

### DIFF
--- a/pyupgrade/_plugins/typing_pep585.py
+++ b/pyupgrade/_plugins/typing_pep585.py
@@ -19,7 +19,7 @@ PEP585_BUILTINS = frozenset((
 
 def _should_rewrite(state: State) -> bool:
     return (
-        state.settings.min_version >= (3, 9) or (
+        state.settings.min_version >= (3, 9) and (
             not state.settings.keep_runtime_typing and
             state.in_annotation and
             'annotations' in state.from_imports['__future__']


### PR DESCRIPTION
At the moment, if you use `--py37-plus`, pyupgrade will apply `pep585` to a file. 

However, that PEP requires builtin typing support from python 3.9 or later, so will generate synactically invalid python 3.7 outputs. 

This change fixes the small bug that causes that behavior.