### PR TITLE
feat: Add --check-only for performing linting only (w/o changing files)

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -329,9 +329,12 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     if filename == '-':
         print(contents_text, end='')
     elif contents_text != contents_text_orig:
-        print(f'Rewriting {filename}', file=sys.stderr)
-        with open(filename, 'w', encoding='UTF-8', newline='') as f:
-            f.write(contents_text)
+        if args.check_only:
+            print(f'Would rewrite {filename}', file=sys.stderr)
+        else:
+            print(f'Rewriting {filename}', file=sys.stderr)
+            with open(filename, 'w', encoding='UTF-8', newline='') as f:
+                f.write(contents_text)
 
     if args.exit_zero_even_if_changed:
         return 0
@@ -342,6 +345,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
+    parser.add_argument('--check-only', action='store_true')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -182,6 +182,15 @@ def test_main_exit_zero_even_if_changed(tmpdir):
     assert not main((str(f), '--exit-zero-even-if-changed'))
 
 
+def test_main_check_only(tmpdir):
+    f = tmpdir.join('t.py')
+    f.write('set((1, 2))\n')
+    assert main((str(f), '--check-only')) == 1
+    assert f.read() == 'set((1, 2))\n'
+    assert main((str(f), '--check-only', '--exit-zero-even-if-changed')) == 0
+    assert f.read() == 'set((1, 2))\n'
+
+
 def test_main_stdin_no_changes(capsys):
     stdin = io.TextIOWrapper(io.BytesIO(b'{1, 2}\n'), 'UTF-8')
     with mock.patch.object(sys, 'stdin', stdin):


### PR DESCRIPTION
A small PR to add `--check-only` mode that does not change any file. This makes it easier to use `pyupgrade` during a linting stage.