### PR TITLE
Enable pre-commit hook for `.pyi` stub files

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
     description: Automatically upgrade syntax for newer versions.
     entry: pyupgrade
     language: python
-    types: [python]
+    types: [python, pyi]
     # for backward compatibility
     files: ''
     minimum_pre_commit_version: 0.15.0


### PR DESCRIPTION
Add `pyi` type to pre-commit hook. Users can run `pyupgrade` for `.pyi` stub files with `pre-commit` automatically.