### PR TITLE
Add --check-only and --diff options

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -329,9 +329,12 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     if filename == '-':
         print(contents_text, end='')
     elif contents_text != contents_text_orig:
-        print(f'Rewriting {filename}', file=sys.stderr)
-        with open(filename, 'w', encoding='UTF-8', newline='') as f:
-            f.write(contents_text)
+        if args.check_only:
+            print(f'File {filename} would be re-written', file=sys.stderr)
+        else:
+            print(f'Rewriting {filename}', file=sys.stderr)
+            with open(filename, 'w', encoding='UTF-8', newline='') as f:
+                f.write(contents_text)
 
     if args.exit_zero_even_if_changed:
         return 0
@@ -343,6 +346,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
+    parser.add_argument('--check-only', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
     parser.add_argument('--keep-runtime-typing', action='store_true')

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import argparse
 import ast
+import difflib
+import os
 import re
 import sys
 import tokenize
@@ -331,6 +333,20 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     elif contents_text != contents_text_orig:
         if args.check_only:
             print(f'File {filename} would be re-written', file=sys.stderr)
+            if args.diff:
+                print(
+                    ''.join(
+                        d for d in difflib.unified_diff(
+                            contents_text_orig.splitlines(keepends=True),
+                            contents_text.splitlines(keepends=True),
+                            fromfile=filename,
+                            tofile=filename,
+                            lineterm=os.linesep,
+                        )
+                    ),
+                    end='',
+                    file=sys.stderr,
+                )
         else:
             print(f'Rewriting {filename}', file=sys.stderr)
             with open(filename, 'w', encoding='UTF-8', newline='') as f:
@@ -347,6 +363,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--check-only', action='store_true')
+    parser.add_argument('--diff', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
     parser.add_argument('--keep-runtime-typing', action='store_true')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -55,6 +55,22 @@ def test_main_changes_check(tmpdir, capsys):
     assert f.read() == 'x = set((1, 2, 3))\n'
 
 
+def test_main_changes_check_diff(tmpdir, capsys):
+    f = tmpdir.join('f.py')
+    f.write('x = set((1, 2, 3))\n')
+    assert main((f.strpath, '--check-only', '--diff')) == 1
+    out, err = capsys.readouterr()
+    assert err == f'''\
+File {f.strpath} would be re-written
+--- {f.strpath}
++++ {f.strpath}
+@@ -1 +1 @@
+-x = set((1, 2, 3))
++x = {{1, 2, 3}}
+'''
+    assert f.read() == 'x = set((1, 2, 3))\n'
+
+
 def test_main_keeps_line_endings(tmpdir, capsys):
     f = tmpdir.join('f.py')
     f.write_binary(b'x = set((1, 2, 3))\r\n')

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -46,6 +46,15 @@ def test_main_changes_a_file(tmpdir, capsys):
     assert f.read() == 'x = {1, 2, 3}\n'
 
 
+def test_main_changes_check(tmpdir, capsys):
+    f = tmpdir.join('f.py')
+    f.write('x = set((1, 2, 3))\n')
+    assert main((f.strpath, '--check-only')) == 1
+    out, err = capsys.readouterr()
+    assert err == f'File {f.strpath} would be re-written\n'
+    assert f.read() == 'x = set((1, 2, 3))\n'
+
+
 def test_main_keeps_line_endings(tmpdir, capsys):
     f = tmpdir.join('f.py')
     f.write_binary(b'x = set((1, 2, 3))\r\n')


### PR DESCRIPTION
Hi all,

I would like to be able to visualize what modifications would be applied by pyupgrade without modifying files on disk.

These are options that are available in other linting tools like black, isort, autoflake, and others.

What do you think?

I am hesitating between --check and --check-only because we see both in other tools.
I would also like to see some colors on the diff (I like colors! :D), but that would require either some external library (which can be annoying) or handling terminal color codes in pyupgrade directly (which can be annoying aswell). I can be a separate PR though!

Last thing, would it be possible to have a version 3.3.3 with these patches so that it can be available for Python 3.7? I don't have much ground to stand on for this as it is the version for Debian 10 which is oldoldstable since Saturday ^^
Your call!

Thanks!