### PR TITLE
Introducing Dry-Run Mode

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -326,6 +326,12 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     )
     contents_text = _fix_tokens(contents_text)
 
+    if args.dry_run:
+        if contents_text != contents_text_orig:
+            print(f'Would rewrite {filename}', file=sys.stderr)
+            return 1
+        return 0
+
     if filename == '-':
         print(contents_text, end='')
     elif contents_text != contents_text_orig:
@@ -342,6 +348,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
 def main(argv: Sequence[str] | None = None) -> int:
     parser = argparse.ArgumentParser()
     parser.add_argument('filenames', nargs='*')
+    parser.add_argument('--dry-run', action='store_true')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -326,18 +326,15 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     )
     contents_text = _fix_tokens(contents_text)
 
-    if args.dry_run:
-        if contents_text != contents_text_orig:
-            print(f'Would rewrite {filename}', file=sys.stderr)
-            return 1
-        return 0
-
     if filename == '-':
         print(contents_text, end='')
     elif contents_text != contents_text_orig:
-        print(f'Rewriting {filename}', file=sys.stderr)
-        with open(filename, 'w', encoding='UTF-8', newline='') as f:
-            f.write(contents_text)
+        if not args.dry_run:
+            print(f'Rewriting {filename}', file=sys.stderr)
+            with open(filename, 'w', encoding='UTF-8', newline='') as f:
+                f.write(contents_text)
+        else:
+            print(f'Would rewrite {filename}', file=sys.stderr)
 
     if args.exit_zero_even_if_changed:
         return 0

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -182,6 +182,22 @@ def test_main_exit_zero_even_if_changed(tmpdir):
     assert not main((str(f), '--exit-zero-even-if-changed'))
 
 
+def test_main_dry_run_with_possible_changes(tmpdir):
+    f = tmpdir.join('t.py')
+    origin = 'set((1, 2))\n'
+    f.write(origin)
+    assert main((str(f), '--dry-run'))
+    assert f.read() == origin
+
+
+def test_main_dry_run_with_no_changes(tmpdir):
+    f = tmpdir.join('t.py')
+    origin = '{1, 2}\n'
+    f.write(origin)
+    assert not main((str(f), '--dry-run'))
+    assert f.read() == origin
+
+
 def test_main_stdin_no_changes(capsys):
     stdin = io.TextIOWrapper(io.BytesIO(b'{1, 2}\n'), 'UTF-8')
     with mock.patch.object(sys, 'stdin', stdin):


### PR DESCRIPTION
I have added a dry-run argument to PyUpgrade, allowing developers to validate Python files without making any changes. This feature provides informative feedback on potential updates without altering the code. People can use it in their own CI/CD tools without using pre-commit. 

Hope, this feature will be accepted as it is currently needed in our project. 

We still can use the approach of finding all the files, and piping them into the PyUpgrade with '-' argument, however it requires another layer of logic.