### PR TITLE
Add usage example to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,18 @@ versions of the language.
 pip install pyupgrade
 ```
 
+## Usage
+
+```console
+$ pyupgrade --help
+usage: pyupgrade [-h] [--exit-zero-even-if-changed] [--keep-percent-format] [--keep-mock] [--keep-runtime-typing] [--py3-plus]
+                 [--py36-plus] [--py37-plus] [--py38-plus] [--py39-plus] [--py310-plus] [--py311-plus]
+                 [filenames ...]
+# ...
+$ pyupgrade example.py
+Rewriting example.py
+```
+
 ## As a pre-commit hook
 
 See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions

--- a/README.md
+++ b/README.md
@@ -16,11 +16,6 @@ pip install pyupgrade
 ## Usage
 
 ```console
-$ pyupgrade --help
-usage: pyupgrade [-h] [--exit-zero-even-if-changed] [--keep-percent-format] [--keep-mock] [--keep-runtime-typing] [--py3-plus]
-                 [--py36-plus] [--py37-plus] [--py38-plus] [--py39-plus] [--py310-plus] [--py311-plus]
-                 [filenames ...]
-# ...
 $ pyupgrade example.py
 Rewriting example.py
 ```


### PR DESCRIPTION
Before this change, there is no indication in the `README.md` that this tool can be run on the command-line. This change makes it clear in `README.md` that this PyPI package can be run on the command-line.