### PR TITLE
fix bug when rewriting deprecated unittest functions

### DIFF
--- a/pyupgrade/_plugins/unittest_aliases.py
+++ b/pyupgrade/_plugins/unittest_aliases.py
@@ -7,6 +7,7 @@ from typing import Iterable
 from tokenize_rt import Offset
 
 from pyupgrade._ast_helpers import ast_to_offset
+from pyupgrade._ast_helpers import has_starargs
 from pyupgrade._data import register
 from pyupgrade._data import State
 from pyupgrade._data import TokenFunc
@@ -59,7 +60,10 @@ def visit_Call(
             isinstance(node.func, ast.Attribute) and
             isinstance(node.func.value, ast.Name) and
             node.func.value.id == 'unittest' and
-            node.func.attr in FUNCTION_MAPPING
+            node.func.attr in FUNCTION_MAPPING and
+            not has_starargs(node) and
+            not node.keywords and
+            len(node.args) == 1
     ):
         func = functools.partial(
             replace_name,

--- a/tests/features/unittest_aliases_test.py
+++ b/tests/features/unittest_aliases_test.py
@@ -7,7 +7,7 @@ from pyupgrade._main import _fix_plugins
 
 
 @pytest.mark.parametrize(
-    ('s',),
+    's',
     (
         pytest.param(
             'class ExampleTests:\n'
@@ -15,6 +15,8 @@ from pyupgrade._main import _fix_plugins
             '        self.assertEqual(1, 1)\n',
             id='not a deprecated alias',
         ),
+        'unittest.makeSuite(Tests, "arg")',
+        'unittest.makeSuite(Tests, prefix="arg")',
     ),
 )
 def test_fix_unittest_aliases_noop(s):


### PR DESCRIPTION
Closes #749.

I saw that #759 was closed without actually fixing the issue.