### PR TITLE
Add config file support

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -341,7 +341,11 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
 
 
 def _build_config_arg_parser() -> configargparse.ArgumentParser:
-    parser = configargparse.ArgumentParser()
+    config_parser = configargparse.TomlConfigParser(['tool.pyupgrade'])
+    parser = configargparse.ArgumentParser(
+        default_config_files=['pyupgrade.toml', 'pyproject.toml'],
+        config_file_parser_class=config_parser,
+    )
 
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -8,6 +8,7 @@ import tokenize
 from typing import Match
 from typing import Sequence
 
+import configargparse
 from tokenize_rt import NON_CODING_TOKENS
 from tokenize_rt import parse_string_literal
 from tokenize_rt import reversed_enumerate
@@ -339,8 +340,9 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
         return contents_text != contents_text_orig
 
 
-def main(argv: Sequence[str] | None = None) -> int:
-    parser = argparse.ArgumentParser()
+def _build_config_arg_parser() -> configargparse.ArgumentParser:
+    parser = configargparse.ArgumentParser()
+
     parser.add_argument('filenames', nargs='*')
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
@@ -378,6 +380,12 @@ def main(argv: Sequence[str] | None = None) -> int:
         '--py312-plus',
         action='store_const', dest='min_version', const=(3, 12),
     )
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_config_arg_parser()
     args = parser.parse_args(argv)
 
     ret = 0

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -348,6 +348,10 @@ def _build_config_arg_parser() -> configargparse.ArgumentParser:
     )
 
     parser.add_argument('filenames', nargs='*')
+    parser.add_argument(
+        '--config-file',
+        is_config_file=True, help='config file path',
+    )
     parser.add_argument('--exit-zero-even-if-changed', action='store_true')
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,6 +19,7 @@ classifiers =
 [options]
 packages = find:
 install_requires =
+    ConfigArgParse>=1.7.0
     tokenize-rt>=5.2.0
 python_requires = >=3.8.1
 


### PR DESCRIPTION
Add support for configuration files in pyupgrade using [`ConfigArgParse`][ConfigArgParse-pypi].

[ConfigArgParse-pypi]: https://pypi.python.org/pypi/ConfigArgParse

By default, we'll look for a `tool.pyupgrade` section in `pyupgrade.toml` or `pyproject.toml` (in that order), and read the configuration from there. Command line arguments will override configuration file settings, which will override command line argument defaults. We also add a `--config-file` option to override the config file path.

Fixes #511.


### Example Output

```console
% pyupgrade -h
usage: pyupgrade [-h] [--config-file CONFIG_FILE] [--exit-zero-even-if-changed] [--keep-percent-format] [--keep-mock] [--keep-runtime-typing] [--py3-plus]
                 [--py36-plus] [--py37-plus] [--py38-plus] [--py39-plus] [--py310-plus] [--py311-plus] [--py312-plus]
                 [filenames ...]

positional arguments:
  filenames

options:
  -h, --help            show this help message and exit
  --config-file CONFIG_FILE
                        config file path
  --exit-zero-even-if-changed
  --keep-percent-format
  --keep-mock
  --keep-runtime-typing
  --py3-plus, --py3-only
  --py36-plus
  --py37-plus
  --py38-plus
  --py39-plus
  --py310-plus
  --py311-plus
  --py312-plus

Args that start with '--' can also be set in a config file (pyupgrade.toml or pyproject.toml or specified via --config-file). Config file syntax is Tom's
Obvious, Minimal Language. See https://github.com/toml-lang/toml/blob/v0.5.0/README.md for details. In general, command-line values override config file
values which override defaults.
```


### TODO

* [x] Add `ConfigArgParse` dependency
* [x] Switch from `argparse` to `configargparse`
* [ ] Add unit tests for config file parsing
* [ ] Add documentation for config file handling