### PR TITLE
prevent dict/set rewrite directly in f-string placeholder

### DIFF
--- a/pyupgrade/_plugins/dict_literals.py
+++ b/pyupgrade/_plugins/dict_literals.py
@@ -53,6 +53,7 @@ def visit_Call(
         parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
+            not isinstance(parent, ast.FormattedValue) and
             isinstance(node.func, ast.Name) and
             node.func.id == 'dict' and
             len(node.args) == 1 and

--- a/pyupgrade/_plugins/set_literals.py
+++ b/pyupgrade/_plugins/set_literals.py
@@ -50,6 +50,7 @@ def visit_Call(
         parent: ast.AST,
 ) -> Iterable[tuple[Offset, TokenFunc]]:
     if (
+            not isinstance(parent, ast.FormattedValue) and
             isinstance(node.func, ast.Name) and
             node.func.id == 'set' and
             len(node.args) == 1 and

--- a/tests/features/dict_literals_test.py
+++ b/tests/features/dict_literals_test.py
@@ -19,6 +19,10 @@ from pyupgrade._main import _fix_plugins
         # Don't rewrite kwargd dicts
         'dict(((a, b) for a, b in y), x=1)',
         'dict(((a, b) for a, b in y), **kwargs)',
+        pytest.param(
+            'f"{dict((a, b) for a, b in y)}"',
+            id='directly inside f-string placeholder',
+        ),
     ),
 )
 def test_fix_dict_noop(s):

--- a/tests/features/set_literals_test.py
+++ b/tests/features/set_literals_test.py
@@ -14,6 +14,14 @@ from pyupgrade._main import _fix_plugins
         # Don't touch weird looking function calls -- use autopep8 or such
         # first
         'set ((1, 2))',
+        pytest.param(
+            'f"{set((1, 2))}"',
+            id='set directly inside f-string placeholder',
+        ),
+        pytest.param(
+            'f"{set(x for x in y)}"',
+            id='set comp directly inside f-string placeholder',
+        ),
     ),
 )
 def test_fix_sets_noop(s):


### PR DESCRIPTION
this can change the syntax by doubling the curly braces

resolves #976