### PR TITLE
add deduplication of types

### DIFF
--- a/pyupgrade/_plugins/typing_pep604.py
+++ b/pyupgrade/_plugins/typing_pep604.py
@@ -116,7 +116,9 @@ def _fix_union(
     else:
         comma_positions = []
 
-    to_delete += _find_duplicated_types(tokens, j, top_level_breaks, lines_with_comments)
+    to_delete += _find_duplicated_types(
+        tokens, j, top_level_breaks, lines_with_comments,
+    )
 
     if tokens[j].line == tokens[k].line:
         del tokens[k]
@@ -141,7 +143,10 @@ def _fix_union(
         del tokens[i:j]
 
 
-def _find_closing_bracket_and_if_contains_none(tokens: list[Token], i: int) -> tuple[int, bool]:
+def _find_closing_bracket_and_if_contains_none(
+    tokens: list[Token],
+    i: int,
+) -> tuple[int, bool]:
     assert tokens[i].src in _OPENING
     depth = 1
     i += 1

--- a/tests/features/typing_pep604_test.py
+++ b/tests/features/typing_pep604_test.py
@@ -312,13 +312,15 @@ def f(x: int | str) -> None: ...
         ),
         pytest.param(
             'from typing import Union\n'
-            'def f(x: Union[list[Union[int, str]], list[Union[str, int]]]): pass\n',
+            'def f(x: Union[list[Union[int, str]], list[Union[str, int]]]):\n'
+            '    pass\n',
 
             'from typing import Union\n'
-            'def f(x: list[int | str]): pass\n',
+            'def f(x: list[int | str]):\n'
+            '    pass\n',
 
             id='general duplicated types',
-            marks=pytest.mark.xfail(reason='requires recursive type searching'),
+            marks=pytest.mark.xfail(reason='requires deeper type evaluation'),
         ),
     ),
 )


### PR DESCRIPTION
Relating to https://github.com/asottile/pyupgrade/issues/982

Took me a while to get round to this, but here we are....

I think there are three different levels of approaching this issue:
1. Remove extra `None` types only:
    ```diff
    -def f(x: Optional[Union[int, None]]): pass
    +def f(x: int | None): pass
    -def g(x: Union[Optional[int], None]): pass
    +def g(x: int | None): pass
    ```
2. Remove any duplicated scalar types at the same depth by name in `Union` blocks:
    ```diff
    -def f(x: Union[Union[Union[Union[a, b], c], d], a]): pass
    +def f(x: a | b | c | d): pass
    -def g(x: Union[a.b | a.c, a.b, list[str], str]): pass
    +def g(x: a.b | a.c | list[str] | str): pass
    ```
3. General deduplication at any depth on any block:
    ```diff
    -def f(x: Union[list[Union[int, str]], list[Union[str, int]]]): pass
    +def f(x: list[int | str]): pass
    ```

I settled on level 2 as this was still possible with a single pass and seemed more useful than just focusing on `None` types.
I couldn't see a way of approaching the general problem (level 3) without recursively making a tree structure and then assessing the leaf nodes. However, I am not deeply familiar with the standard python libraries for parsing ASTs etc., so if there are simple built in methods for problems like this I would be interested to know!

I used the existing scan in `_fix_union` to determine the delimitators at `depth==1` between the types. This seemed to work well, but I definitely ran into some interesting edge cases when it came to handling comments, whitespace and multilines.

I have managed to get this working for a variety of test cases, and I would be interested to hear your feedback.

Btw I enjoy your YouTube content! I have learnt a lot of niche things I would have struggled to pick up otherwise. So thank you for that!