### PR TITLE
Convert asyncio.coroutine to async def

### DIFF
--- a/tests/features/asyncio_coroutine_test.py
+++ b/tests/features/asyncio_coroutine_test.py
@@ -1,0 +1,24 @@
+import pytest
+
+from pyupgrade._data import Settings
+from pyupgrade._main import _fix_plugins
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        pytest.param(
+            'import asyncio\n\n'
+            '@asyncio.coroutine\n'
+            'def foo():\n'
+            '    pass\n',
+            'async def foo():\n'
+            '    pass\n',
+            id='Convert to async',
+        ),
+    ),
+)
+def test_replace_coroutine_with_async_def(s, expected):
+    ret = _fix_plugins(s, settings=Settings(min_version=(3, 5)))
+    assert ret == expected


### PR DESCRIPTION
I've encountered some old python libraries that still use asyncio.coroutine instead of async def. From what I see this change was around 3.5. I've just added a failing test with xfail on it for now as a start. I'm not even sure this is a relevant feature. It's just something that has annoyed me a couple of times. 