### PR TITLE
Basic failing test for auto-remove TYPE_CHECKING block for Protocol

### DIFF
--- a/tests/features/type_checking_block_test.py
+++ b/tests/features/type_checking_block_test.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import pytest
+
+from pyupgrade._data import Settings
+from pyupgrade._main import _fix_plugins
+
+
+@pytest.mark.xfail
+@pytest.mark.parametrize(
+    ("s", "expected"),
+    (
+        pytest.param(
+            "from typing import TYPE_CHECKING\n\n"
+            "if TYPE_CHECKING:\n"
+            "    from typing import Protocol\n"
+            "else:\n"
+            "    Protocol = object\n",
+            "from typing import TYPE_CHECKING\n\nfrom typing import Protocol\n",
+            id="import of Protocol",
+        ),
+    ),
+)
+def test_fix_typing_text(s, expected):
+    ret = _fix_plugins(s, settings=Settings(min_version=(3, 8)))
+    assert ret == expected

--- a/tests/features/type_checking_block_test.py
+++ b/tests/features/type_checking_block_test.py
@@ -21,6 +21,6 @@ from pyupgrade._main import _fix_plugins
         ),
     ),
 )
-def test_fix_typing_text(s, expected):
+def test_remove_type_checking_block_for_protocol(s, expected):
     ret = _fix_plugins(s, settings=Settings(min_version=(3, 8)))
     assert ret == expected


### PR DESCRIPTION
This adds a basic failing test with the example that you have in #849.