### PR TITLE
feat: add `--keep-string-format` flag to preserve formatting methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,7 @@ Availability:
 
 Availability:
 - `--py36-plus` is passed on the commandline.
+- Unless `--keep-string-format` is passed.
 
 ```diff
 -'{foo} {bar}'.format(foo=foo, bar=bar)

--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -22,6 +22,7 @@ class Settings(NamedTuple):
     keep_percent_format: bool = False
     keep_mock: bool = False
     keep_runtime_typing: bool = False
+    keep_string_format: bool = False
 
 
 class State(NamedTuple):

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -322,6 +322,7 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
             keep_percent_format=args.keep_percent_format,
             keep_mock=args.keep_mock,
             keep_runtime_typing=args.keep_runtime_typing,
+            keep_string_format=args.keep_string_format,
         ),
     )
     contents_text = _fix_tokens(contents_text)
@@ -346,6 +347,7 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
     parser.add_argument('--keep-runtime-typing', action='store_true')
+    parser.add_argument('--keep-string-format', action='store_true')
     parser.add_argument(
         '--py3-plus', '--py3-only',
         action='store_const', dest='min_version', default=(3,), const=(3,),

--- a/pyupgrade/_plugins/fstrings.py
+++ b/pyupgrade/_plugins/fstrings.py
@@ -134,7 +134,8 @@ def visit_Call(
                     i += 1
         else:
             if (
-                    state.settings.min_version >= (3, 7) or
-                    not contains_await(node)
+                    not state.settings.keep_string_format and
+                    (state.settings.min_version >= (3, 7) or
+                     not contains_await(node))
             ):
                 yield ast_to_offset(node), _fix_fstring

--- a/tests/features/fstrings_test.py
+++ b/tests/features/fstrings_test.py
@@ -79,3 +79,11 @@ def test_fix_fstrings_await_py37():
     s = "async def c(): return '{}'.format(await 1+foo())"
     expected = "async def c(): return f'{await 1+foo()}'"
     assert _fix_plugins(s, settings=Settings(min_version=(3, 7))) == expected
+
+
+def test_keep_string_format():
+    s = '"{} {}".format(a, b)'
+    assert _fix_plugins(
+        s, 
+        settings=Settings(min_version=(3, 6), keep_string_format=True),
+    ) == s


### PR DESCRIPTION
### PR Title

feat: add `--keep-string-format` flag to preserve formatting methods

### PR Description

**The String Formatting Landscape**
Python's string formatting has evolved through several stages:

1. `%-formatting` → `str.format()` → `f-strings` → `t-strings` (Python 3.13+)
2. **f-strings** (introduced in 3.6) offer concise syntax but have limitations for i18n
3. **t-strings** (PEP 501/PEP 1013) solve i18n challenges but require explicit annotation (`t""`)
4. Automatic `.format()` → f-string conversion ignores these nuances

**Core Problems**:

1. **Breaks i18n workflows**:

   - When run before extraction tools like `makemessages`, conversion makes strings undetectable

   ```python
   # Before: Extractable
   "Welcome, {user}".format(user=name)
   
   # After pyupgrade: Unextractable
   f"Welcome, {name}"
   
   # Running makemessages → translation lost
   ```

2. **Blocks future t-string adoption**:

   - Converting to f-strings creates migration hurdles for PEP 1013 t-strings:

   ```python
   # Desired end state (t-string):
   t"Welcome, {user}"  # Translatable with context
   
   # Problematic path:
   .format() → f-string → t-string   # Double conversion
   
   # Ideal path:
   .format() → t-string               # Direct migration
   ```

   - Automatic conversion forces intermediate f-string state

3. **Incomplete solution**:

   - f-strings aren't always the optimal endpoint

   - Different formats serve different needs:

     ```
     | Format        | i18n | Static Analysis | Readability |
     |---------------|------|-----------------|-------------|
     | %-format      | ✗    | ✗               | ✗           |
     | .format()     | ✓    | ✓               | ✓           |
     | f-string      | ✗    | ✗               | ✓✓          |
     | t-string      | ✓✓   | ✓✓              | ✓✓          |
     ```

**Solution**:
Add `--keep-string-format` flag to:

1. Preserve `.format()` during i18n extraction
2. Enable direct migration to t-strings
3. Give teams control over formatting transitions

**Usage**:

```bash
# Preserve formatting during i18n extraction
pyupgrade --keep-string-format src/

# Do something...

# After extraction, run without flag to upgrade
pyupgrade src/

# When ready for t-strings:
pyupgrade --keep-string-format src/  # Maintain until migration
```

**Changes**:

1. Added `keep_string_format` setting (default: `False`)
2. Implemented CLI flag `--keep-string-format`
3. Modified f-string conversion logic to respect the flag
4. Added test cases for preservation behavior

This approach:

- Protects existing i18n workflows
- Enables smooth adoption of future standards
- Recognizes that formatting choices require context
- Maintains pyupgrade's value while adding flexibility