### PR TITLE
Add --check flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ versions of the language.
 pip install pyupgrade
 ```
 
-## As a pre-commit hook
+### As a pre-commit hook
 
 See [pre-commit](https://github.com/pre-commit/pre-commit) for instructions
 
@@ -25,6 +25,29 @@ Sample `.pre-commit-config.yaml`:
     hooks:
     -   id: pyupgrade
 ```
+
+## Options
+
+- `--exit-zero-even-if-changed`  
+  Exit with status code 0 even if files were/would be modified.
+
+- `--keep-percent-format`  
+  Keep `%` formatting instead of converting to `.format()` or f-strings.
+
+- `--keep-mock`  
+  Don’t rewrite `mock` imports to `unittest.mock`.
+
+- `--keep-runtime-typing`  
+  Keep older `typing` imports (e.g. `List`, `Optional`) even if newer syntax is available.
+
+- `--check`  
+  Show files that would be changed, but don’t modify them.
+
+Use a `--pyXY-plus` flag to specify the minimum supported Python version (e.g., `--py36-plus`, `--py310-plus`).  
+This determines which syntax upgrades are applied.
+
+By default, pyupgrade assumes Python 3.0+ (`--py3-plus`).
+
 
 ## Implemented features
 

--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -329,9 +329,12 @@ def _fix_file(filename: str, args: argparse.Namespace) -> int:
     if filename == '-':
         print(contents_text, end='')
     elif contents_text != contents_text_orig:
-        print(f'Rewriting {filename}', file=sys.stderr)
-        with open(filename, 'w', encoding='UTF-8', newline='') as f:
-            f.write(contents_text)
+        if args.check:
+            print(f'Would rewrite {filename}', file=sys.stderr)
+        else:
+            print(f'Rewriting {filename}', file=sys.stderr)
+            with open(filename, 'w', encoding='UTF-8', newline='') as f:
+                f.write(contents_text)
 
     if args.exit_zero_even_if_changed:
         return 0
@@ -346,6 +349,11 @@ def main(argv: Sequence[str] | None = None) -> int:
     parser.add_argument('--keep-percent-format', action='store_true')
     parser.add_argument('--keep-mock', action='store_true')
     parser.add_argument('--keep-runtime-typing', action='store_true')
+    parser.add_argument(
+        '--check',
+        action='store_true',
+        help='Only output files to change, do not change files.',
+    )
     parser.add_argument(
         '--py3-plus', '--py3-only',
         action='store_const', dest='min_version', default=(3,), const=(3,),

--- a/tests/main_test.py
+++ b/tests/main_test.py
@@ -198,3 +198,17 @@ def test_main_stdin_with_changes(capsys):
         assert main(('-',)) == 1
     out, err = capsys.readouterr()
     assert out == '{1, 2}\n'
+
+
+def test_main_keeps_unchanged_with_check_flag(tmpdir, capsys):
+    initial_contents = 'x = set((1, 2, 3))\n'
+    f = tmpdir.join('f.py')
+    f.write(initial_contents)
+    # --check should detect the needed change but not rewrite the file
+    assert main((f.strpath, '--check')) == 1
+
+    out, err = capsys.readouterr()
+    assert err == f'Would rewrite {f.strpath}\n'
+
+    # file content remains unchanged
+    assert f.read() == initial_contents


### PR DESCRIPTION
This pull requests adds a simple `--check` flag to allow running the program to verify whether any upgrade would be made without actually writing to file. This can be useful if users want to add pyupgrade in their code quality pipeline. It should play nicely with any other existing flag.

Additionally, I documented all flags in the README, including the new one.

A test for the new flag is included.