### PR TITLE
implement wildcards

### DIFF
--- a/pyupgrade/_main.py
+++ b/pyupgrade/_main.py
@@ -6,6 +6,7 @@ import re
 import sys
 import tokenize
 from collections.abc import Sequence
+from glob import glob
 from re import Match
 
 from tokenize_rt import NON_CODING_TOKENS
@@ -394,7 +395,11 @@ def main(argv: Sequence[str] | None = None) -> int:
 
     ret = 0
     for filename in args.filenames:
-        ret |= _fix_file(filename, args)
+        if '*' in filename:
+            for f in glob(filename):
+                ret |= _fix_file(f, args)
+        else:
+            ret |= _fix_file(filename, args)
     return ret
 
 


### PR DESCRIPTION
while attempting to use this library on numerous files in order to modernize older libraries I bumped into a problem were multiple needed to be traversed so I came up with a cleaver idea to help eliminate some problems by implementing wildcards. Now on Linux this may work without what I have added in but in Windows this does matter. So hopefully this addition will prove useful in the long run. Here's an example that I have tested with this new additional feature such as upgrading h11's `3.8` code on over to `3.9` which writing all of these files down can be extremely annoying...

```
> pyupgrade h11/*.py --py39-plus

Rewriting h11\_connection.py
Rewriting h11\_events.py
Rewriting h11\_headers.py
Rewriting h11\_readers.py
Rewriting h11\_receivebuffer.py
Rewriting h11\_state.py
Rewriting h11\_util.py
Rewriting h11\_writers.py
```