### PR TITLE
Fix crash on nested TypedDict/NamedTuple call expressions

### DIFF
--- a/pyupgrade/_plugins/typing_classes.py
+++ b/pyupgrade/_plugins/typing_classes.py
@@ -17,6 +17,15 @@ from pyupgrade._data import TokenFunc
 from pyupgrade._token_helpers import KEYWORDS
 
 
+def _can_unparse(node: ast.expr) -> bool:
+    try:
+        _unparse(node)
+    except NotImplementedError:
+        return False
+    else:
+        return True
+
+
 def _unparse(node: ast.expr) -> str:
     if isinstance(node, ast.Name):
         return node.id
@@ -178,7 +187,8 @@ def visit_Assign(
                     isinstance(tup.elts[0], ast.Constant) and
                     isinstance(tup.elts[0].value, str) and
                     tup.elts[0].value.isidentifier() and
-                    tup.elts[0].value not in KEYWORDS
+                    tup.elts[0].value not in KEYWORDS and
+                    _can_unparse(tup.elts[1])
                     for tup in node.value.args[1].elts
                 )
         ):
@@ -195,6 +205,10 @@ def visit_Assign(
                 len(node.value.keywords) > 0 and
                 not any(
                     keyword.arg == 'total'
+                    for keyword in node.value.keywords
+                ) and
+                all(
+                    _can_unparse(keyword.value)
                     for keyword in node.value.keywords
                 )
         ):
@@ -224,6 +238,10 @@ def visit_Assign(
                     k.value.isidentifier() and
                     k.value not in KEYWORDS
                     for k in node.value.args[1].keys
+                ) and
+                all(
+                    _can_unparse(v)
+                    for v in node.value.args[1].values
                 )
         ):
             func = functools.partial(_fix_dict_typed_dict, call=node.value)

--- a/tests/features/typing_classes_test.py
+++ b/tests/features/typing_classes_test.py
@@ -57,6 +57,11 @@ from pyupgrade._main import _fix_plugins
             'C = NamedTuple("C", [("a", int)])\n',
             id='relative imports',
         ),
+        pytest.param(
+            'from typing import NamedTuple, TypedDict\n'
+            'C = NamedTuple("C", [("a", TypedDict("a", {"x": int}))])\n',
+            id='NamedTuple with nested call in type',
+        ),
     ),
 )
 def test_typing_named_tuple_noop(s):
@@ -265,6 +270,16 @@ def test_fix_typing_named_tuple(s, expected):
         pytest.param(
             'D = typing.TypedDict("D", x=int, total=False)',
             id='kw_typed_dict with total',
+        ),
+        pytest.param(
+            'from typing import TypedDict\n'
+            'D = TypedDict("D", {"x": list[TypedDict("x", {"y": int})]})\n',
+            id='nested TypedDict in dict values',
+        ),
+        pytest.param(
+            'from typing import TypedDict\n'
+            'D = TypedDict("D", x=TypedDict("x", {"y": int}))\n',
+            id='nested TypedDict in keyword values',
         ),
     ),
 )


### PR DESCRIPTION
## Summary
- pyupgrade crashed with `NotImplementedError` when rewriting dict-style `TypedDict` calls containing nested `TypedDict(...)` as values
- The `_unparse` helper doesn't handle `ast.Call` nodes, which appear when TypedDict definitions are nested inline
- Rather than implementing a full `ast.Call` unparser, skip the class-syntax rewrite when any type annotation contains an unsupported expression
- Added `_can_unparse` guard to all three rewrite paths: dict TypedDict, keyword TypedDict, and NamedTuple

Fixes #804

## Test plan
- [x] Added 3 test cases: nested TypedDict in dict values, nested TypedDict in keyword values, nested call in NamedTuple types
- [x] All 1014 tests pass (1011 existing + 3 new)
- [x] Simple TypedDicts still get rewritten correctly
- [x] Reproducer from #804 no longer crashes