### PR TITLE
Rewrite concurrent.futures.TimeoutError to TimeoutError on 3.11+

### DIFF
--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -39,6 +39,7 @@ RECORD_FROM_IMPORTS = frozenset((
     'asyncio',
     'collections',
     'collections.abc',
+    'concurrent.futures',
     'functools',
     'mmap',
     'os',

--- a/pyupgrade/_plugins/exceptions.py
+++ b/pyupgrade/_plugins/exceptions.py
@@ -36,6 +36,7 @@ _TARGETS = (
     _Target('OSError', None, 'WindowsError', (3,)),
     _Target('TimeoutError', 'socket', 'timeout', (3, 10)),
     _Target('TimeoutError', 'asyncio', 'TimeoutError', (3, 11)),
+    _Target('TimeoutError', 'concurrent.futures', 'TimeoutError', (3, 11)),
 )
 
 
@@ -79,6 +80,16 @@ def _get_rewrite(
                 isinstance(node.value, ast.Name) and
                 node.attr == target.name and
                 node.value.id == target.module
+        ):
+            return target
+        elif (
+                target.module is not None and
+                '.' in target.module and
+                isinstance(node, ast.Attribute) and
+                isinstance(node.value, ast.Attribute) and
+                isinstance(node.value.value, ast.Name) and
+                node.attr == target.name and
+                f'{node.value.value.id}.{node.value.attr}' == target.module
         ):
             return target
     else:

--- a/tests/features/exceptions_test.py
+++ b/tests/features/exceptions_test.py
@@ -95,6 +95,17 @@ def test_fix_exceptions_noop(s):
             (3, 10),
             id='except asyncio.TimeoutError() is noop <3.11',
         ),
+        pytest.param(
+            'raise concurrent.futures.TimeoutError()',
+            (3, 10),
+            id='raise concurrent.futures.TimeoutError() is noop <3.11',
+        ),
+        pytest.param(
+            'try: ...\n'
+            'except concurrent.futures.TimeoutError: ...\n',
+            (3, 10),
+            id='except concurrent.futures.TimeoutError is noop <3.11',
+        ),
     ),
 )
 def test_fix_exceptions_version_specific_noop(s, version):
@@ -270,6 +281,20 @@ def test_fix_exceptions(s, expected):
             (3, 11),
             id='asyncio.TimeoutError',
         ),
+        pytest.param(
+            'raise concurrent.futures.TimeoutError(1)\n',
+            'raise TimeoutError(1)\n',
+            (3, 11),
+            id='concurrent.futures.TimeoutError',
+        ),
+        pytest.param(
+            'try: ...\n'
+            'except concurrent.futures.TimeoutError: ...\n',
+            'try: ...\n'
+            'except TimeoutError: ...\n',
+            (3, 11),
+            id='except concurrent.futures.TimeoutError',
+        ),
     ),
 )
 def test_fix_exceptions_versioned(s, expected, version):
@@ -284,6 +309,19 @@ except (asyncio.TimeoutError, WindowsError): ...
     expected = '''\
 try: ...
 except (TimeoutError, OSError): ...
+'''
+
+    assert _fix_plugins(s, settings=Settings(min_version=(3, 11))) == expected
+
+
+def test_can_rewrite_concurrent_futures_timeout():
+    s = '''\
+try: ...
+except (concurrent.futures.TimeoutError, asyncio.TimeoutError): ...
+'''
+    expected = '''\
+try: ...
+except TimeoutError: ...
 '''
 
     assert _fix_plugins(s, settings=Settings(min_version=(3, 11))) == expected


### PR DESCRIPTION
## Summary
- Adds `concurrent.futures.TimeoutError` as a rewrite target to the builtin `TimeoutError` for Python 3.11+
- Extends `_get_rewrite()` to handle dotted module paths (two-level `Attribute` nodes like `concurrent.futures.TimeoutError`)
- Adds `'concurrent.futures'` to `RECORD_FROM_IMPORTS` so `from concurrent.futures import TimeoutError` is tracked

Fixes #819

## Test plan
- Added version-specific noop tests for `raise` and `except` with `concurrent.futures.TimeoutError` on <3.11
- Added rewrite tests for `raise concurrent.futures.TimeoutError(1)` and `except concurrent.futures.TimeoutError`
- Added deduplication test for `except (concurrent.futures.TimeoutError, asyncio.TimeoutError)`
- All 1016 existing tests continue to pass