### PR TITLE
Remove `object` from bases in `type()` calls

### DIFF
--- a/pyupgrade/_plugins/new_style_classes.py
+++ b/pyupgrade/_plugins/new_style_classes.py
@@ -1,15 +1,62 @@
 from __future__ import annotations
 
 import ast
+import functools
 from collections.abc import Iterable
 
 from tokenize_rt import Offset
+from tokenize_rt import Token
 
 from pyupgrade._ast_helpers import ast_to_offset
+from pyupgrade._ast_helpers import has_starargs
 from pyupgrade._data import register
 from pyupgrade._data import State
 from pyupgrade._data import TokenFunc
+from pyupgrade._token_helpers import find_op
+from pyupgrade._token_helpers import parse_call_args
 from pyupgrade._token_helpers import remove_base_class
+
+
+def _fix_type_call_bases(
+        i: int,
+        tokens: list[Token],
+        *,
+        arg_count: int,
+) -> None:
+    j = find_op(tokens, i, '(')
+    func_args, end = parse_call_args(tokens, j)
+    # func_args[1] is the second argument (bases tuple)
+    bases_start, bases_end = func_args[1]
+
+    # find the ( and ) of the bases tuple
+    k = bases_start
+    while tokens[k].src != '(':
+        k += 1
+    paren_start = k
+
+    k = bases_end - 1
+    while tokens[k].src != ')':
+        k -= 1
+    paren_end = k
+
+    if arg_count == 1:
+        # single base (object,) -> ()
+        tokens[paren_start + 1:paren_end] = []
+    else:
+        # multiple bases -- remove each `object` and its comma
+        # rebuild the tuple contents without `object`
+        inner_args, _ = parse_call_args(tokens, paren_start)
+        new_parts = []
+        for arg_start, arg_end in inner_args:
+            src = ''.join(t.src for t in tokens[arg_start:arg_end]).strip()
+            if src != 'object':
+                new_parts.append(src)
+
+        if new_parts:
+            new_inner = ', '.join(new_parts)
+            if len(new_parts) == 1:
+                new_inner += ','
+            tokens[paren_start + 1:paren_end] = [Token('CODE', new_inner)]
 
 
 @register(ast.ClassDef)
@@ -21,3 +68,40 @@ def visit_ClassDef(
     for base in node.bases:
         if isinstance(base, ast.Name) and base.id == 'object':
             yield ast_to_offset(base), remove_base_class
+
+
+@register(ast.Call)
+def visit_Call(
+        state: State,
+        node: ast.Call,
+        parent: ast.AST,
+) -> Iterable[tuple[Offset, TokenFunc]]:
+    if (
+            isinstance(node.func, ast.Name) and
+            node.func.id == 'type' and
+            len(node.args) == 3 and
+            not node.keywords and
+            not has_starargs(node) and
+            isinstance(node.args[1], ast.Tuple) and
+            any(
+                isinstance(elt, ast.Name) and elt.id == 'object'
+                for elt in node.args[1].elts
+            )
+    ):
+        object_count = sum(
+            1 for elt in node.args[1].elts
+            if isinstance(elt, ast.Name) and elt.id == 'object'
+        )
+        non_object_count = len(node.args[1].elts) - object_count
+        if non_object_count == 0:
+            # all bases are object -- replace with empty tuple
+            func = functools.partial(
+                _fix_type_call_bases,
+                arg_count=1,
+            )
+        else:
+            func = functools.partial(
+                _fix_type_call_bases,
+                arg_count=len(node.args[1].elts),
+            )
+        yield ast_to_offset(node), func

--- a/tests/features/new_style_classes_test.py
+++ b/tests/features/new_style_classes_test.py
@@ -106,3 +106,75 @@ def test_fix_classes_noop(s):
 def test_fix_classes(s, expected):
     ret = _fix_plugins(s, settings=Settings())
     assert ret == expected
+
+
+@pytest.mark.parametrize(
+    's',
+    (
+        pytest.param(
+            'A = type("A", (), {})\n',
+            id='already empty bases',
+        ),
+        pytest.param(
+            'A = type("A", (B,), {})\n',
+            id='non-object base',
+        ),
+        pytest.param(
+            'type("A", (object,))\n',
+            id='type call with only 2 args',
+        ),
+        pytest.param(
+            'type(x)\n',
+            id='type call with 1 arg',
+        ),
+        pytest.param(
+            'type("A", (object,), {}, extra)\n',
+            id='type call with 4 args',
+        ),
+        pytest.param(
+            'type("A", (object,), {}, key=val)\n',
+            id='type call with keyword args',
+        ),
+        pytest.param(
+            'type("A", object, {})\n',
+            id='bases not a tuple',
+        ),
+    ),
+)
+def test_fix_type_call_noop(s):
+    assert _fix_plugins(s, settings=Settings()) == s
+
+
+@pytest.mark.parametrize(
+    ('s', 'expected'),
+    (
+        pytest.param(
+            'A = type("A", (object,), {})\n',
+            'A = type("A", (), {})\n',
+            id='single object base',
+        ),
+        pytest.param(
+            'A = type("A", (object, ), {})\n',
+            'A = type("A", (), {})\n',
+            id='single object base with trailing space',
+        ),
+        pytest.param(
+            'A = type("A", (Foo, object), {})\n',
+            'A = type("A", (Foo,), {})\n',
+            id='object with other base',
+        ),
+        pytest.param(
+            'A = type("A", (object, Foo), {})\n',
+            'A = type("A", (Foo,), {})\n',
+            id='object before other base',
+        ),
+        pytest.param(
+            'A = type("A", (Foo, object, Bar), {})\n',
+            'A = type("A", (Foo, Bar), {})\n',
+            id='object between two bases',
+        ),
+    ),
+)
+def test_fix_type_call(s, expected):
+    ret = _fix_plugins(s, settings=Settings())
+    assert ret == expected


### PR DESCRIPTION
## Summary
- Rewrites `type("A", (object,), {})` to `type("A", (), {})`, analogous to the existing rewrite of `class A(object)` to `class A`
- Also handles `object` mixed with other bases: `type("A", (Foo, object), {})` → `type("A", (Foo,), {})`
- Only matches 3-argument `type()` calls with a tuple literal as the second argument, no keywords

Fixes #532

## Test plan
- Added 7 noop tests (empty bases, non-object base, wrong arg count, keyword args, non-tuple bases)
- Added 5 rewrite tests (single object, trailing space, object with other base, object first, object between bases)
- All 1023 tests pass (7 new + 1016 existing)