### PR TITLE
fix: handle Literal with negative numbers in NamedTuple rewrite

### DIFF
--- a/pyupgrade/_plugins/typing_classes.py
+++ b/pyupgrade/_plugins/typing_classes.py
@@ -44,6 +44,8 @@ def _unparse(node: ast.expr) -> str:
         return repr(node.value)
     elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return f'{_unparse(node.left)} | {_unparse(node.right)}'
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return f'-{_unparse(node.operand)}'
     else:
         raise NotImplementedError(ast.dump(node))
 

--- a/tests/features/typing_classes_test.py
+++ b/tests/features/typing_classes_test.py
@@ -120,6 +120,14 @@ def test_typing_named_tuple_noop(s):
             id='type with ellipsis',
         ),
         pytest.param(
+            'C = typing.NamedTuple("C", [("a", Literal[-1])])',
+
+            'class C(typing.NamedTuple):\n'
+            '    a: Literal[-1]',
+
+            id='Literal with negative integer',
+        ),
+        pytest.param(
             'C = typing.NamedTuple("C", [("a", Callable[[Any], None])])',
 
             'class C(typing.NamedTuple):\n'


### PR DESCRIPTION
fixes #1060.

`Literal[-1]` is represented in the AST as `UnaryOp(USub, Constant(1))`, which `_unparse()` did not handle for the functional `NamedTuple` rewrite.

This adds the missing `USub` case and a regression test for the issue reproducer.

Tested with:

```bash
python3 -m pytest tests/features/typing_classes_test.py -q
python3 -m pytest -q
```
