### PR TITLE
rewrite concurrent.futures.TimeoutError to TimeoutError on py311+

### DIFF
--- a/pyupgrade/_data.py
+++ b/pyupgrade/_data.py
@@ -39,6 +39,7 @@ RECORD_FROM_IMPORTS = frozenset((
     'asyncio',
     'collections',
     'collections.abc',
+    'concurrent.futures',
     'functools',
     'mmap',
     'os',

--- a/pyupgrade/_plugins/exceptions.py
+++ b/pyupgrade/_plugins/exceptions.py
@@ -36,7 +36,17 @@ _TARGETS = (
     _Target('OSError', None, 'WindowsError', (3,)),
     _Target('TimeoutError', 'socket', 'timeout', (3, 10)),
     _Target('TimeoutError', 'asyncio', 'TimeoutError', (3, 11)),
+    _Target('TimeoutError', 'concurrent.futures', 'TimeoutError', (3, 11)),
 )
+
+
+def _is_dotted_name(node: ast.AST, dotted: str) -> bool:
+    parts = dotted.split('.')
+    for part in reversed(parts[1:]):
+        if not (isinstance(node, ast.Attribute) and node.attr == part):
+            return False
+        node = node.value
+    return isinstance(node, ast.Name) and node.id == parts[0]
 
 
 def _fix_except(
@@ -76,9 +86,8 @@ def _get_rewrite(
         elif (
                 target.module is not None and
                 isinstance(node, ast.Attribute) and
-                isinstance(node.value, ast.Name) and
                 node.attr == target.name and
-                node.value.id == target.module
+                _is_dotted_name(node.value, target.module)
         ):
             return target
     else:

--- a/tests/features/exceptions_test.py
+++ b/tests/features/exceptions_test.py
@@ -95,6 +95,17 @@ def test_fix_exceptions_noop(s):
             (3, 10),
             id='except asyncio.TimeoutError() is noop <3.11',
         ),
+        pytest.param(
+            'raise concurrent.futures.TimeoutError()',
+            (3, 10),
+            id='raise concurrent.futures.TimeoutError() is noop <3.11',
+        ),
+        pytest.param(
+            'try: ...\n'
+            'except concurrent.futures.TimeoutError: ...\n',
+            (3, 10),
+            id='except concurrent.futures.TimeoutError is noop <3.11',
+        ),
     ),
 )
 def test_fix_exceptions_version_specific_noop(s, version):
@@ -270,6 +281,32 @@ def test_fix_exceptions(s, expected):
             (3, 11),
             id='asyncio.TimeoutError',
         ),
+        pytest.param(
+            'raise concurrent.futures.TimeoutError(1)\n',
+            'raise TimeoutError(1)\n',
+            (3, 11),
+            id='concurrent.futures.TimeoutError raise',
+        ),
+        pytest.param(
+            'try: ...\n'
+            'except concurrent.futures.TimeoutError: ...\n',
+
+            'try: ...\n'
+            'except TimeoutError: ...\n',
+
+            (3, 11),
+            id='concurrent.futures.TimeoutError except',
+        ),
+        pytest.param(
+            'try: ...\n'
+            'except (concurrent.futures.TimeoutError,): ...\n',
+
+            'try: ...\n'
+            'except TimeoutError: ...\n',
+
+            (3, 11),
+            id='concurrent.futures.TimeoutError except tuple',
+        ),
     ),
 )
 def test_fix_exceptions_versioned(s, expected, version):
@@ -285,5 +322,22 @@ except (asyncio.TimeoutError, WindowsError): ...
 try: ...
 except (TimeoutError, OSError): ...
 '''
+
+    assert _fix_plugins(s, settings=Settings(min_version=(3, 11))) == expected
+
+
+def test_can_rewrite_dotted_module_alongside_others():
+    s = (
+        'try: ...\n'
+        'except (\n'
+        '    asyncio.TimeoutError,\n'
+        '    concurrent.futures.TimeoutError,\n'
+        '    WindowsError,\n'
+        '): ...\n'
+    )
+    expected = (
+        'try: ...\n'
+        'except (TimeoutError, OSError): ...\n'
+    )
 
     assert _fix_plugins(s, settings=Settings(min_version=(3, 11))) == expected


### PR DESCRIPTION
Closes the remaining piece of #819: rewrite `concurrent.futures.TimeoutError` to the builtin `TimeoutError` when `--py311-plus` (or later) is in effect.

In Python 3.11 `concurrent.futures.TimeoutError` became an alias for the builtin `TimeoutError`, the same way `asyncio.TimeoutError` did. #885 already handles `socket.timeout` (3.10+) and `asyncio.TimeoutError` (3.11+); this PR adds the third member of that set.

### Approach

* Add `_Target('TimeoutError', 'concurrent.futures', 'TimeoutError', (3, 11))` to `_TARGETS` in `pyupgrade/_plugins/exceptions.py`.
* Add `'concurrent.futures'` to `RECORD_FROM_IMPORTS` so a `from concurrent.futures import TimeoutError` is tracked the same way `asyncio` is.
* The `ast.Attribute` branch of `_get_rewrite` previously only handled single-segment module names (it required `node.value` to be an `ast.Name`). I extracted a small `_is_dotted_name` helper that walks an `Attribute` chain so dotted modules like `concurrent.futures` are matched too. The helper degenerates to the original `Name` check for single-segment modules, so the existing `asyncio.TimeoutError`/`os.error`/etc. rewrites continue to behave identically.

### Behavior

```python
# input (py311+)
raise concurrent.futures.TimeoutError(1)
try: ...
except concurrent.futures.TimeoutError: ...
try: ...
except (concurrent.futures.TimeoutError, ValueError): ...

# output
raise TimeoutError(1)
try: ...
except TimeoutError: ...
try: ...
except (TimeoutError, ValueError): ...
```

On py310 and below the rewrite is a noop, matching the existing behavior for `asyncio.TimeoutError`.

### Tests

Added to `tests/features/exceptions_test.py`:

* `test_fix_exceptions_version_specific_noop` cases for `raise`/`except concurrent.futures.TimeoutError` at `(3, 10)`.
* `test_fix_exceptions_versioned` cases for the `raise`, `except`, and `except (...,)` rewrites at `(3, 11)`.
* `test_can_rewrite_dotted_module_alongside_others` covering the interaction with the existing disparate-names tuple rewrite.

Full test suite: `1017 passed, 4 xfailed`. `pre-commit run --all-files` clean (flake8, autopep8, mypy).