### PR TITLE
fix: remove the 3.13 TypedDict replacement to accomodate PEP-728

### DIFF
--- a/pyupgrade/_plugins/imports.py
+++ b/pyupgrade/_plugins/imports.py
@@ -236,7 +236,6 @@ REPLACE_EXACT = {
         ('typing_extensions', 'TypeIs'): 'typing',
         ('typing_extensions', 'TypeVar'): 'typing',
         ('typing_extensions', 'TypeVarTuple'): 'typing',
-        ('typing_extensions', 'TypedDict'): 'typing',
         ('typing_extensions', 'deprecated'): 'warnings',
         ('typing_extensions', 'get_protocol_members'): 'typing',
         ('typing_extensions', 'is_protocol'): 'typing',


### PR DESCRIPTION
In relation to #1071 

The replacement will probably come back for 3.15 but at the moment there is no 3.15 code.

The tests only test the general replacement logic and I'm assuming that these definitions here
are not tested on its own, so I didn't change the test files.