### PR TITLE
fix NamedTuple/TypedDict rewrite crash on int Literal values

### DIFF
--- a/pyupgrade/_plugins/typing_classes.py
+++ b/pyupgrade/_plugins/typing_classes.py
@@ -40,8 +40,14 @@ def _unparse(node: ast.expr) -> str:
         return '...'
     elif isinstance(node, ast.List):
         return '[{}]'.format(', '.join(_unparse(elt) for elt in node.elts))
-    elif isinstance(node, ast.Constant) and node.value in {True, False, None}:
+    elif (
+            isinstance(node, ast.Constant) and (
+                node.value is None or isinstance(node.value, (bool, int))
+            )
+    ):
         return repr(node.value)
+    elif isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.USub):
+        return f'-{_unparse(node.operand)}'
     elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return f'{_unparse(node.left)} | {_unparse(node.right)}'
     else:

--- a/tests/features/typing_classes_test.py
+++ b/tests/features/typing_classes_test.py
@@ -220,6 +220,16 @@ def test_typing_named_tuple_noop(s):
 
             id='BitOr unparse error',
         ),
+        pytest.param(
+            'from typing import Literal, NamedTuple\n'
+            'C = NamedTuple("C", [("field", Literal[-1, 2])])\n',
+
+            'from typing import Literal, NamedTuple\n'
+            'class C(NamedTuple):\n'
+            '    field: Literal[-1, 2]\n',
+
+            id='with Literal of ints',
+        ),
     ),
 )
 def test_fix_typing_named_tuple(s, expected):
@@ -314,6 +324,16 @@ def test_typing_typed_dict_noop(s):
             "    a: typing.Literal['b', b'c']\n",
 
             id='with Literal of bytes',
+        ),
+        pytest.param(
+            'import typing\n'
+            'D = typing.TypedDict("D", {"a": typing.Literal[-1, 2, None]})\n',
+
+            'import typing\n'
+            'class D(typing.TypedDict):\n'
+            '    a: typing.Literal[-1, 2, None]\n',
+
+            id='with Literal of ints',
         ),
         pytest.param(
             'import typing\n'


### PR DESCRIPTION
Closes #1060.

`_unparse` tested constants with `node.value in {True, False, None}`, so `Literal[1]` passed by accident (`1 == True`) while `Literal[2]` and `Literal[-1]` raised `NotImplementedError` and crashed the rewrite. Now int constants are matched by type and a `USub` branch handles negative values.
