### PR TITLE
Fix NamedTuple rewrite for negative literals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.egg-info
 *.pyc
+.DS_Store
 /.coverage
 /.tox

--- a/pyupgrade/_plugins/typing_classes.py
+++ b/pyupgrade/_plugins/typing_classes.py
@@ -42,6 +42,13 @@ def _unparse(node: ast.expr) -> str:
         return '[{}]'.format(', '.join(_unparse(elt) for elt in node.elts))
     elif isinstance(node, ast.Constant) and node.value in {True, False, None}:
         return repr(node.value)
+    elif (
+            isinstance(node, ast.UnaryOp) and
+            isinstance(node.op, ast.USub) and
+            isinstance(node.operand, ast.Constant) and
+            isinstance(node.operand.value, int)
+    ):
+        return f'-{node.operand.value}'
     elif isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
         return f'{_unparse(node.left)} | {_unparse(node.right)}'
     else:

--- a/tests/features/typing_classes_test.py
+++ b/tests/features/typing_classes_test.py
@@ -220,6 +220,16 @@ def test_typing_named_tuple_noop(s):
 
             id='BitOr unparse error',
         ),
+        pytest.param(
+            'from typing import Literal, NamedTuple\n'
+            'C = NamedTuple("C", [("field", Literal[-1])])\n',
+
+            'from typing import Literal, NamedTuple\n'
+            'class C(NamedTuple):\n'
+            '    field: Literal[-1]\n',
+
+            id='negative integer literal',
+        ),
     ),
 )
 def test_fix_typing_named_tuple(s, expected):


### PR DESCRIPTION
Fixes #1060.

## Summary

- support negative integer literal AST nodes when rewriting functional typing classes
- add a regression case for `NamedTuple` fields annotated with `Literal[-1]`
- ignore macOS `.DS_Store` metadata

## Tests

- `python -m pytest -q tests/features/typing_classes_test.py` (52 passed)
- `coverage run -m pytest -q && coverage report` (1012 passed, 4 xfailed, 100% coverage)
- `pre-commit run --all-files --show-diff-on-failure`
