### PR TITLE
`argparse_suggest_on_error`: fix missing container for a string

### DIFF
--- a/pyupgrade/_plugins/argparse_suggest_on_error.py
+++ b/pyupgrade/_plugins/argparse_suggest_on_error.py
@@ -27,7 +27,7 @@ def visit_Call(
                 node.func,
                 state.from_imports,
                 ('argparse',),
-                'ArgumentParser',
+                ('ArgumentParser',),
             ) and
             node.keywords
     ):

--- a/tests/features/argparse_suggest_on_error_test.py
+++ b/tests/features/argparse_suggest_on_error_test.py
@@ -18,6 +18,8 @@ def test_noop_before_315():
         'argparse.ArgumentParser()',
         # explicitly off
         'argparse.ArgumentParser(suggest_on_error=False)',
+        # regression test
+        'argparse.ArgumentPar(suggest_on_error=True)',
     ),
 )
 def test_noop(s):


### PR DESCRIPTION
Issue was mostly harmless, but was making plugin apply on weird cases like:

```python
import argparse

argparse.ArgumentPars(suggest_on_error=True)
```

`is_name_attr` expecting `Container[str]` and technically just `str` also passes as a container of strings.

https://github.com/asottile/pyupgrade/blob/44e8a53fed5f7a8a43765180f9515349050739ce/pyupgrade/_ast_helpers.py#L22-L27