### PR TITLE
identity_equality: fix ints-floats bug/support complex and tuple

### DIFF
--- a/pyupgrade/_plugins/identity_equality.py
+++ b/pyupgrade/_plugins/identity_equality.py
@@ -36,7 +36,7 @@ def _fix_is_literal(
 def _is_literal(n: ast.AST) -> bool:
     return (
         isinstance(n, ast.Constant) and
-        n.value not in {True, False} and
+        not isinstance(n.value, bool) and
         isinstance(n.value, (str, bytes, int, float))
     )
 

--- a/pyupgrade/_plugins/identity_equality.py
+++ b/pyupgrade/_plugins/identity_equality.py
@@ -38,6 +38,11 @@ def _is_literal(n: ast.AST) -> bool:
         isinstance(n, ast.Constant) and
         not isinstance(n.value, bool) and
         isinstance(n.value, (str, bytes, int, float, complex))
+    ) or (
+        # Nested tuples are ignored, since CPython never optimizes them
+        # and hence never warns.
+        isinstance(n, ast.Tuple) and
+        all(isinstance(el, ast.Constant) for el in n.elts)
     )
 
 

--- a/pyupgrade/_plugins/identity_equality.py
+++ b/pyupgrade/_plugins/identity_equality.py
@@ -37,7 +37,7 @@ def _is_literal(n: ast.AST) -> bool:
     return (
         isinstance(n, ast.Constant) and
         not isinstance(n.value, bool) and
-        isinstance(n.value, (str, bytes, int, float))
+        isinstance(n.value, (str, bytes, int, float, complex))
     )
 
 

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -35,6 +35,9 @@ def test_fix_is_compare_to_literal_noop(s):
         pytest.param('x is u""', 'x == u""', id='unicode string'),
         pytest.param('x is b""', 'x == b""', id='bytes'),
         pytest.param('x is 1.5', 'x == 1.5', id='float'),
+        # Regression tests - ensure we don't mistake those cases for `x is True`.
+        pytest.param('x is 1', 'x == 1', id='int equals bool True'),
+        pytest.param('x is 1.0', 'x == 1.0', id='float equals bool True'),
         pytest.param('x == 5 is 5', 'x == 5 == 5', id='compound compare'),
         pytest.param(
             'if (\n'

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -44,7 +44,7 @@ def test_fix_is_compare_to_literal_noop(s):
         pytest.param('x is (None,)', 'x == (None,)', id='tuple with None'),
         pytest.param('x is (True, 1)', 'x == (True, 1)', id='tuple with bool'),
         pytest.param('x is (...,)', 'x == (...,)', id='tuple with ellipsis'),
-        # Regression tests - ensure we don't mistake those cases for `x is True`.
+        # Regression tests - ensure we don't mistake the cases for `x is True`.
         pytest.param('x is 1', 'x == 1', id='int equals bool True'),
         pytest.param('x is 1.0', 'x == 1.0', id='float equals bool True'),
         pytest.param('x == 5 is 5', 'x == 5 == 5', id='compound compare'),

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -15,12 +15,14 @@ from pyupgrade._main import _fix_plugins
         'x is ...',
         'x is (not 5)',
         'x is 5 + 5',
-        # pyupgrade is timid about containers since the original can be
+        # pyupgrade is timid about mutable containers since the original can be
         # always-False, but the rewritten code could be `True`.
-        'x is ()',
         'x is []',
         'x is {}',
         'x is {1}',
+        # Tuple with a non-constants is also always-False.
+        'x is ([1,2,3],)',
+        'x is ((1,2,3),)',
     ),
 )
 def test_fix_is_compare_to_literal_noop(s):
@@ -38,6 +40,10 @@ def test_fix_is_compare_to_literal_noop(s):
         pytest.param('x is b""', 'x == b""', id='bytes'),
         pytest.param('x is 1.5', 'x == 1.5', id='float'),
         pytest.param('x is 2j', 'x == 2j', id='complex'),
+        pytest.param('x is (1,2,3)', 'x == (1,2,3)', id='tuple'),
+        pytest.param('x is (None,)', 'x == (None,)', id='tuple with None'),
+        pytest.param('x is (True, 1)', 'x == (True, 1)', id='tuple with bool'),
+        pytest.param('x is (...,)', 'x == (...,)', id='tuple with ellipsis'),
         # Regression tests - ensure we don't mistake those cases for `x is True`.
         pytest.param('x is 1', 'x == 1', id='int equals bool True'),
         pytest.param('x is 1.0', 'x == 1.0', id='float equals bool True'),

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -12,6 +12,7 @@ from pyupgrade._main import _fix_plugins
         'x is True',
         'x is False',
         'x is None',
+        'x is ...',
         'x is (not 5)',
         'x is 5 + 5',
         # pyupgrade is timid about containers since the original can be

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -31,6 +31,7 @@ def test_fix_is_compare_to_literal_noop(s):
     (
         pytest.param('x is 5', 'x == 5', id='`is`'),
         pytest.param('x is not 5', 'x != 5', id='`is not`'),
+        pytest.param('5 is x', '5 == x', id='literal on the left'),
         pytest.param('x is ""', 'x == ""', id='string'),
         pytest.param('x is u""', 'x == u""', id='unicode string'),
         pytest.param('x is b""', 'x == b""', id='bytes'),

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -35,6 +35,7 @@ def test_fix_is_compare_to_literal_noop(s):
         pytest.param('x is u""', 'x == u""', id='unicode string'),
         pytest.param('x is b""', 'x == b""', id='bytes'),
         pytest.param('x is 1.5', 'x == 1.5', id='float'),
+        pytest.param('x is 2j', 'x == 2j', id='complex'),
         # Regression tests - ensure we don't mistake those cases for `x is True`.
         pytest.param('x is 1', 'x == 1', id='int equals bool True'),
         pytest.param('x is 1.0', 'x == 1.0', id='float equals bool True'),


### PR DESCRIPTION
Hi! Fixing 1 bug in `identity_equality` and expanding fix to cover 2 more types. 

Possibly could have been 3 PRs, but changes are interleaved, so submitting them as one.
Commits are separated for readability, but I'll summarize them here also.

1. For skipping bools check was relying on `in {True, False}`:

https://github.com/asottile/pyupgrade/blob/f08b199e76297c88173992813df2cd00614b9601/pyupgrade/_plugins/identity_equality.py#L38-L40

Since `in` is using `==` as a fallback, so the check end up also skipping `1.0`, `0.0`, `0`, `1` and cases like `x is 1`, etc.

2. Added support for `complex` numbers, they also have a warning at runtime. Though use of this is minimal is probably.

```
>>> a = 5j
>>> a is 5j
<python-input-2>:1: SyntaxWarning: "is" with 'complex' literal. Did you mean "=="?
```

3. Added support for tuples that have all its elements as constants (including singletons that are usually skipped), Python warns about them too - they're also optimized during Python compilation as constants and sometimes `x is (1,2,3)` results to `True`, relying on the implementation detail.
In theory we can also warn about nested tuples, but they're never optimized by Python and hence it never warns about them, so it's a different kind of error - same as if it would be with `is []`, `is {}`, etc.

```python
>>> a is (1,2,3)
<python-input-5>:1: SyntaxWarning: "is" with 'tuple' literal. Did you mean "=="?
False
>>> a is (None, True, ...)
<python-input-1>:1: SyntaxWarning: "is" with 'tuple' literal. Did you mean "=="?
False
>>> a is ((1,2,3), 4)
False
>>> a is ([1,2,3], 4)
False
```