### PR TITLE
identity_equality: fix skipping int/float that equal True/False

### DIFF
--- a/pyupgrade/_plugins/identity_equality.py
+++ b/pyupgrade/_plugins/identity_equality.py
@@ -36,7 +36,7 @@ def _fix_is_literal(
 def _is_literal(n: ast.AST) -> bool:
     return (
         isinstance(n, ast.Constant) and
-        n.value not in {True, False} and
+        not isinstance(n.value, bool) and
         isinstance(n.value, (str, bytes, int, float))
     )
 

--- a/tests/features/identity_equality_test.py
+++ b/tests/features/identity_equality_test.py
@@ -35,6 +35,9 @@ def test_fix_is_compare_to_literal_noop(s):
         pytest.param('x is u""', 'x == u""', id='unicode string'),
         pytest.param('x is b""', 'x == b""', id='bytes'),
         pytest.param('x is 1.5', 'x == 1.5', id='float'),
+        # Regression tests - ensure we don't mistake the cases for `x is True`.
+        pytest.param('x is 1', 'x == 1', id='int equals bool True'),
+        pytest.param('x is 1.0', 'x == 1.0', id='float equals bool True'),
         pytest.param('x == 5 is 5', 'x == 5 == 5', id='compound compare'),
         pytest.param(
             'if (\n'


### PR DESCRIPTION
Spitting a change from https://github.com/asottile/pyupgrade/pull/1082.

For skipping bools check was relying on `in {True, False}`:

https://github.com/asottile/pyupgrade/blob/f08b199e76297c88173992813df2cd00614b9601/pyupgrade/_plugins/identity_equality.py#L38-L40

Since `in` is using `==` as a fallback, so the check end up also skipping `1.0`, `0.0`, `0`, `1` and hence the cases like `x is 1`, `x is 1.0`.

Adding an explicit check for `bool` type to exclude bools directly, added regression tests.