### PR TITLE
Fix crash on unparsable TypedDict values

### DIFF
--- a/pyupgrade/_plugins/typing_classes.py
+++ b/pyupgrade/_plugins/typing_classes.py
@@ -48,6 +48,15 @@ def _unparse(node: ast.expr) -> str:
         raise NotImplementedError(ast.dump(node))
 
 
+def _can_unparse(node: ast.expr) -> bool:
+    try:
+        _unparse(node)
+    except NotImplementedError:
+        return False
+    else:
+        return True
+
+
 def _typed_class_replacement(
         tokens: list[Token],
         i: int,
@@ -178,7 +187,8 @@ def visit_Assign(
                     isinstance(tup.elts[0], ast.Constant) and
                     isinstance(tup.elts[0].value, str) and
                     tup.elts[0].value.isidentifier() and
-                    tup.elts[0].value not in KEYWORDS
+                    tup.elts[0].value not in KEYWORDS and
+                    _can_unparse(tup.elts[1])
                     for tup in node.value.args[1].elts
                 )
         ):
@@ -195,6 +205,10 @@ def visit_Assign(
                 len(node.value.keywords) > 0 and
                 not any(
                     keyword.arg == 'total'
+                    for keyword in node.value.keywords
+                ) and
+                all(
+                    _can_unparse(keyword.value)
                     for keyword in node.value.keywords
                 )
         ):
@@ -224,6 +238,10 @@ def visit_Assign(
                     k.value.isidentifier() and
                     k.value not in KEYWORDS
                     for k in node.value.args[1].keys
+                ) and
+                all(
+                    _can_unparse(v)
+                    for v in node.value.args[1].values
                 )
         ):
             func = functools.partial(_fix_dict_typed_dict, call=node.value)

--- a/tests/features/typing_classes_test.py
+++ b/tests/features/typing_classes_test.py
@@ -53,6 +53,10 @@ from pyupgrade._main import _fix_plugins
             id='NamedTuple starargs',
         ),
         pytest.param(
+            'C = typing.NamedTuple("C", [("a", f(int))])',
+            id='NamedTuple with unparsable (call) attribute type',
+        ),
+        pytest.param(
             'from .typing import NamedTuple\n'
             'C = NamedTuple("C", [("a", int)])\n',
             id='relative imports',
@@ -265,6 +269,22 @@ def test_fix_typing_named_tuple(s, expected):
         pytest.param(
             'D = typing.TypedDict("D", x=int, total=False)',
             id='kw_typed_dict with total',
+        ),
+        pytest.param(
+            'D = typing.TypedDict("D", x=f(int))',
+            id='kw_typed_dict with unparsable (call) value',
+        ),
+        pytest.param(
+            'D = typing.TypedDict("D", {"x": f(int)})',
+            id='dict TypedDict with unparsable (call) value',
+        ),
+        pytest.param(
+            'import typing\n'
+            'D = typing.TypedDict(\n'
+            '    "D",\n'
+            '    {"x": list[typing.TypedDict("X", {"y": int})]},\n'
+            ')\n',
+            id='dict TypedDict with nested TypedDict call value (#804)',
         ),
     ),
 )


### PR DESCRIPTION
Fixes #804.

The typing_classes plugin can raise NotImplementedError when a TypedDict value contains an expression that _unparse cannot handle.

This adds a guard so those cases are left unchanged instead of crashing pyupgrade, with regression tests covering the affected cases.